### PR TITLE
fix: restore issue labels when undoing a delete (KAN-3)

### DIFF
--- a/src-tauri/src/commands/issues.rs
+++ b/src-tauri/src/commands/issues.rs
@@ -323,7 +323,13 @@ pub fn delete_issue(state: State<AppState>, id: i64) -> Result<(), String> {
     state.rt.block_on(async {
         let old_issue = sqlx::query_as::<_, Issue>("SELECT * FROM issues WHERE id = ?")
             .bind(id).fetch_one(&state.pool).await?;
-        let old_snapshot = serde_json::to_string(&old_issue).unwrap_or_default();
+
+        // Also snapshot label associations so undo can restore them
+        let labels: Vec<i64> = sqlx::query_scalar("SELECT label_id FROM issue_labels WHERE issue_id = ?")
+            .bind(id).fetch_all(&state.pool).await?;
+        let mut snapshot_val = serde_json::to_value(&old_issue).unwrap();
+        snapshot_val.as_object_mut().unwrap().insert("label_ids".to_string(), serde_json::to_value(&labels).unwrap());
+        let old_snapshot = serde_json::to_string(&snapshot_val).unwrap_or_default();
 
         sqlx::query("DELETE FROM issues WHERE id = ?").bind(id).execute(&state.pool).await?;
 

--- a/src-tauri/src/commands/undo.rs
+++ b/src-tauri/src/commands/undo.rs
@@ -38,6 +38,18 @@ pub fn undo(state: State<AppState>) -> Result<Option<UndoLogEntry>, String> {
                         .bind(issue.position).bind(issue.estimate).bind(&issue.due_date)
                         .bind(&issue.created_at).bind(&issue.updated_at)
                         .execute(&state.pool).await.map_err(|e| e.to_string())?;
+
+                    // Restore labels if present in snapshot
+                    let snapshot_val: serde_json::Value = serde_json::from_str(before).unwrap_or_default();
+                    if let Some(label_ids) = snapshot_val.get("label_ids").and_then(|v| v.as_array()) {
+                        for label_val in label_ids {
+                            if let Some(label_id) = label_val.as_i64() {
+                                sqlx::query("INSERT INTO issue_labels (issue_id, label_id) VALUES (?, ?)")
+                                    .bind(issue.id).bind(label_id)
+                                    .execute(&state.pool).await.map_err(|e| e.to_string())?;
+                            }
+                        }
+                    }
                 }
             }
             ("create", "project") => {


### PR DESCRIPTION
## Summary
- `delete_issue` now includes label_ids in the undo snapshot
- Undo handler for delete restores issue_labels rows from the snapshot

## Test plan
- [ ] Delete an issue with labels, undo, verify labels are restored