### PR TITLE
fix: await onDelete before closing IssueDetailPanel

### DIFF
--- a/src/components/IssueDetailPanel.tsx
+++ b/src/components/IssueDetailPanel.tsx
@@ -136,7 +136,7 @@ export function IssueDetailPanel({
           <button onClick={() => onDuplicate(issueId)} className="rounded p-1 hover:bg-accent" title="Duplicate">
             <Copy className="h-4 w-4 text-muted-foreground" />
           </button>
-          <button onClick={() => { onDelete(issueId); onClose(); }} className="rounded p-1 hover:bg-destructive/20" title="Delete">
+          <button onClick={async () => { await onDelete(issueId); onClose(); }} className="rounded p-1 hover:bg-destructive/20" title="Delete">
             <Trash2 className="h-4 w-4 text-muted-foreground" />
           </button>
           <button onClick={onClose} className="rounded p-1 hover:bg-accent" title="Close (Esc)">


### PR DESCRIPTION
## Summary
- Fixes KAN-9: the delete button in `IssueDetailPanel` was not awaiting the `onDelete` promise before calling `onClose`, which could close the panel before the delete completes, hiding errors and leaving the UI inconsistent.
- Made the `onClick` handler `async` and added `await` before `onDelete(issueId)`.

## Test plan
- [ ] Open the issue detail panel and click the delete button
- [ ] Verify the panel stays open until the delete operation completes
- [ ] Simulate a delete failure and verify the error is surfaced to the user