### PR TITLE
fix(board): resolve drag-and-drop position collision (KAN-7)

### DIFF
--- a/src/components/BoardView.tsx
+++ b/src/components/BoardView.tsx
@@ -77,7 +77,12 @@ export function BoardView({
       const columnIssues = (issuesByStatus.get(overIssue.status_id) || [])
         .filter(i => i.id !== draggedIssue.id);
       const overIndex = columnIssues.findIndex(i => i.id === overIssue.id);
-      if (overIndex <= 0) {
+      if (overIndex === -1) {
+        // Over-issue not in filtered column; append to end
+        targetPosition = columnIssues.length > 0
+          ? columnIssues[columnIssues.length - 1].position + 1
+          : 0;
+      } else if (overIndex === 0) {
         targetPosition = overIssue.position - 0.5;
       } else {
         targetPosition = (columnIssues[overIndex - 1].position + overIssue.position) / 2;

--- a/src/components/BoardView.tsx
+++ b/src/components/BoardView.tsx
@@ -74,7 +74,14 @@ export function BoardView({
     const overIssue = issues.find((i) => i.id === over.id);
     if (overIssue) {
       targetStatusId = overIssue.status_id;
-      targetPosition = overIssue.position;
+      const columnIssues = (issuesByStatus.get(overIssue.status_id) || [])
+        .filter(i => i.id !== draggedIssue.id);
+      const overIndex = columnIssues.findIndex(i => i.id === overIssue.id);
+      if (overIndex <= 0) {
+        targetPosition = overIssue.position - 0.5;
+      } else {
+        targetPosition = (columnIssues[overIndex - 1].position + overIssue.position) / 2;
+      }
     } else {
       // Dropped on a column
       targetStatusId = over.id as number;


### PR DESCRIPTION
## Summary
- Fixed position collision when dragging an issue onto another issue
- Position now calculated as midpoint between target and predecessor

## Test plan
- [ ] Drag issue onto another within same column
- [ ] Drag to top of column
- [ ] Drag between columns