### PR TITLE
fix: replace side panel with full dialog for issue detail view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -197,19 +197,6 @@ function App() {
                 />
               )}
 
-              {selectedIssueId && (
-                <IssueDetailPanel
-                  issueId={selectedIssueId}
-                  statuses={statuses}
-                  members={members}
-                  projectLabels={labels}
-                  onClose={() => setSelectedIssueId(null)}
-                  onUpdate={async (id, input) => { await updateIssue(id, input); }}
-                  onDelete={async (id) => { await deleteIssue(id); setSelectedIssueId(null); }}
-                  onDuplicate={async (id) => { await duplicateIssue(id); }}
-                  onClickIssue={(issue) => setSelectedIssueId(issue.id)}
-                />
-              )}
             </div>
           </>
         )}
@@ -252,6 +239,20 @@ function App() {
           </div>
         )}
       </div>
+
+      {selectedIssueId && (
+        <IssueDetailPanel
+          issueId={selectedIssueId}
+          statuses={statuses}
+          members={members}
+          projectLabels={labels}
+          onClose={() => setSelectedIssueId(null)}
+          onUpdate={async (id, input) => { await updateIssue(id, input); }}
+          onDelete={async (id) => { await deleteIssue(id); setSelectedIssueId(null); }}
+          onDuplicate={async (id) => { await duplicateIssue(id); }}
+          onClickIssue={(issue) => setSelectedIssueId(issue.id)}
+        />
+      )}
 
       {/* Modals */}
       {showCreateProject && (

--- a/src/components/IssueDetailPanel.tsx
+++ b/src/components/IssueDetailPanel.tsx
@@ -128,7 +128,11 @@ export function IssueDetailPanel({
   const currentPriority = priorities.find(p => p.value === issue.priority) || priorities[4];
 
   return (
-    <div className="flex h-full w-[480px] flex-col border-l border-border bg-card">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
+      <div
+        className="flex h-[85vh] w-full max-w-3xl flex-col rounded-lg border border-border bg-card shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
       {/* Header */}
       <div className="flex items-center justify-between border-b border-border px-4 py-3">
         <span className="text-sm text-muted-foreground">{issue.identifier}</span>
@@ -495,6 +499,7 @@ export function IssueDetailPanel({
             </div>
           </div>
         )}
+      </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Converts `IssueDetailPanel` from a 480px side panel to a centered modal dialog overlay (max-w-3xl, 85vh)
- Adds backdrop click-to-close behavior
- Moves panel rendering outside the board flex container so it overlays properly as a modal

## Test plan
- [ ] Open an issue from the board/list/tree view and verify it appears as a centered dialog
- [ ] Click the backdrop (dark overlay) to close the dialog
- [ ] Press Escape to close the dialog
- [ ] Verify all existing functionality (edit title, description, status, priority, comments, etc.) still works
- [ ] Confirm the board content is no longer pushed/resized when the dialog is open

Resolves KAN-22