### PR TITLE
fix: refresh UI on external DB writes (KAN-19)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,7 +4,10 @@ pub mod models;
 mod state;
 
 use state::AppState;
+use tauri::Emitter;
 use tauri::Manager;
+
+use std::time::{Duration, SystemTime};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -15,6 +18,30 @@ pub fn run() {
             let rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
             let pool = rt.block_on(db::init_db())?;
             app.manage(AppState { pool, rt });
+
+            // Watch the SQLite DB file for external modifications (CLI/MCP writes)
+            let app_handle = app.handle().clone();
+            std::thread::spawn(move || {
+                let db_path = dirs::home_dir()
+                    .expect("Failed to resolve home directory")
+                    .join(".kanban/data.db");
+                let mut last_modified = std::fs::metadata(&db_path)
+                    .and_then(|m| m.modified())
+                    .unwrap_or(SystemTime::UNIX_EPOCH);
+
+                loop {
+                    std::thread::sleep(Duration::from_secs(2));
+                    if let Ok(meta) = std::fs::metadata(&db_path) {
+                        if let Ok(modified) = meta.modified() {
+                            if modified > last_modified {
+                                last_modified = modified;
+                                let _ = app_handle.emit("db-changed", ());
+                            }
+                        }
+                    }
+                }
+            });
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from "react";
+import { listen } from "@tauri-apps/api/event";
 import { Sidebar } from "./components/Sidebar";
 import { ProjectHeader, type ViewMode } from "./components/ProjectHeader";
 import { BoardView } from "./components/BoardView";
@@ -124,6 +125,17 @@ function App() {
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
   }, [selectedIssueId, showSearch, showCreateIssue, showCreateProject, showNotifications, refreshIssues, refreshStatuses, refreshProjects]);
+
+  // Listen for external DB changes (CLI/MCP writes) and refresh all data
+  useEffect(() => {
+    const unlisten = listen("db-changed", () => {
+      refreshProjects();
+      refreshIssues();
+      refreshStatuses();
+      refreshLabels();
+    });
+    return () => { unlisten.then(fn => fn()); };
+  }, [refreshProjects, refreshIssues, refreshStatuses, refreshLabels]);
 
   const handleQuickCreate = async (statusId: number, title: string) => {
     if (!selectedProjectId) return;


### PR DESCRIPTION
Polls DB file for changes every 2s, emits Tauri event to refresh all UI data