### PR TITLE
fix: replace full refresh with optimistic updates in hooks

### DIFF
--- a/src/hooks/use-issues.ts
+++ b/src/hooks/use-issues.ts
@@ -22,24 +22,24 @@ export function useIssues(projectId: number | null) {
 
   const create = async (input: Parameters<typeof api.createIssue>[0]) => {
     const issue = await api.createIssue(input);
-    await refresh();
+    setIssues(prev => [...prev, issue]);
     return issue;
   };
 
   const update = async (id: number, input: Parameters<typeof api.updateIssue>[1]) => {
     const issue = await api.updateIssue(id, input);
-    await refresh();
+    setIssues(prev => prev.map(i => i.id === id ? issue : i));
     return issue;
   };
 
   const remove = async (id: number) => {
     await api.deleteIssue(id);
-    await refresh();
+    setIssues(prev => prev.filter(i => i.id !== id));
   };
 
   const duplicate = async (id: number) => {
     const issue = await api.duplicateIssue(id);
-    await refresh();
+    setIssues(prev => [...prev, issue]);
     return issue;
   };
 

--- a/src/hooks/use-members.ts
+++ b/src/hooks/use-members.ts
@@ -21,19 +21,19 @@ export function useMembers() {
 
   const create = async (input: Parameters<typeof api.createMember>[0]) => {
     const member = await api.createMember(input);
-    await refresh();
+    setMembers(prev => [...prev, member]);
     return member;
   };
 
   const update = async (id: number, input: Parameters<typeof api.updateMember>[1]) => {
     const member = await api.updateMember(id, input);
-    await refresh();
+    setMembers(prev => prev.map(m => m.id === id ? member : m));
     return member;
   };
 
   const remove = async (id: number) => {
     await api.deleteMember(id);
-    await refresh();
+    setMembers(prev => prev.filter(m => m.id !== id));
   };
 
   return { members, loading, refresh, create, update, remove };

--- a/src/hooks/use-projects.ts
+++ b/src/hooks/use-projects.ts
@@ -21,19 +21,19 @@ export function useProjects() {
 
   const create = async (input: { name: string; description?: string; icon?: string; prefix: string }) => {
     const project = await api.createProject(input);
-    await refresh();
+    setProjects(prev => [...prev, project]);
     return project;
   };
 
   const update = async (id: number, input: { name?: string; description?: string; icon?: string; status?: string }) => {
     const project = await api.updateProject(id, input);
-    await refresh();
+    setProjects(prev => prev.map(p => p.id === id ? project : p));
     return project;
   };
 
   const remove = async (id: number) => {
     await api.deleteProject(id);
-    await refresh();
+    setProjects(prev => prev.filter(p => p.id !== id));
   };
 
   return { projects, loading, refresh, create, update, remove };


### PR DESCRIPTION
## Summary
- Replaced `await refresh()` calls in `use-issues.ts`, `use-projects.ts`, and `use-members.ts` mutation functions with direct local state updates using the server response
- Eliminates UI flickering caused by full data re-fetches after every create/update/delete operation
- `refresh()` remains available for manual refreshes (undo/redo, db-watcher)

## Test plan
- [ ] Create an issue and verify it appears instantly without a full list refresh
- [ ] Update an issue (e.g., change status via drag-and-drop) and verify no flicker
- [ ] Delete an issue and verify it disappears instantly
- [ ] Duplicate an issue and verify it appears instantly
- [ ] Verify undo/redo still works correctly (uses `refresh()`)
- [ ] Repeat the above for projects and members

Fixes KAN-18