### PR TITLE
feat: add custom fields support for issues (KAN-25)

### DIFF
--- a/src-tauri/migrations/20240103000000_custom_fields.sql
+++ b/src-tauri/migrations/20240103000000_custom_fields.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS custom_fields (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    field_type TEXT NOT NULL DEFAULT 'text',
+    options TEXT,
+    position INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS issue_custom_field_values (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    issue_id INTEGER NOT NULL REFERENCES issues(id) ON DELETE CASCADE,
+    field_id INTEGER NOT NULL REFERENCES custom_fields(id) ON DELETE CASCADE,
+    value TEXT,
+    UNIQUE(issue_id, field_id)
+);

--- a/src-tauri/src/commands/custom_fields.rs
+++ b/src-tauri/src/commands/custom_fields.rs
@@ -1,0 +1,178 @@
+use crate::models::{CustomField, CustomFieldValue};
+use crate::state::AppState;
+use serde::Deserialize;
+use tauri::State;
+
+#[derive(Deserialize)]
+pub struct CreateCustomFieldInput {
+    pub project_id: i64,
+    pub name: String,
+    pub field_type: Option<String>,
+    pub options: Option<String>,
+    pub position: Option<i64>,
+}
+
+#[derive(Deserialize)]
+pub struct UpdateCustomFieldInput {
+    pub name: Option<String>,
+    pub field_type: Option<String>,
+    pub options: Option<String>,
+    pub position: Option<i64>,
+}
+
+#[tauri::command]
+pub fn list_custom_fields(
+    state: State<AppState>,
+    project_id: i64,
+) -> Result<Vec<CustomField>, String> {
+    state
+        .rt
+        .block_on(async {
+            sqlx::query_as::<_, CustomField>(
+                "SELECT * FROM custom_fields WHERE project_id = ? ORDER BY position ASC, id ASC",
+            )
+            .bind(project_id)
+            .fetch_all(&state.pool)
+            .await
+        })
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn create_custom_field(
+    state: State<AppState>,
+    input: CreateCustomFieldInput,
+) -> Result<CustomField, String> {
+    if input.name.trim().is_empty() {
+        return Err("name cannot be empty".to_string());
+    }
+    let field_type = input.field_type.unwrap_or_else(|| "text".to_string());
+    match field_type.as_str() {
+        "text" | "number" | "date" | "select" => {}
+        _ => return Err(format!("invalid field_type: {}", field_type)),
+    }
+    let position = input.position.unwrap_or(0);
+    state
+        .rt
+        .block_on(async {
+            let result = sqlx::query(
+                "INSERT INTO custom_fields (project_id, name, field_type, options, position) VALUES (?, ?, ?, ?, ?)",
+            )
+            .bind(input.project_id)
+            .bind(input.name.trim())
+            .bind(&field_type)
+            .bind(&input.options)
+            .bind(position)
+            .execute(&state.pool)
+            .await?;
+
+            sqlx::query_as::<_, CustomField>("SELECT * FROM custom_fields WHERE id = ?")
+                .bind(result.last_insert_rowid())
+                .fetch_one(&state.pool)
+                .await
+        })
+        .map_err(|e: sqlx::Error| e.to_string())
+}
+
+#[tauri::command]
+pub fn update_custom_field(
+    state: State<AppState>,
+    id: i64,
+    input: UpdateCustomFieldInput,
+) -> Result<CustomField, String> {
+    if let Some(ref ft) = input.field_type {
+        match ft.as_str() {
+            "text" | "number" | "date" | "select" => {}
+            _ => return Err(format!("invalid field_type: {}", ft)),
+        }
+    }
+    state
+        .rt
+        .block_on(async {
+            let existing = sqlx::query_as::<_, CustomField>("SELECT * FROM custom_fields WHERE id = ?")
+                .bind(id)
+                .fetch_one(&state.pool)
+                .await
+                .map_err(|_| sqlx::Error::RowNotFound)?;
+
+            let name = input.name.unwrap_or(existing.name);
+            let field_type = input.field_type.unwrap_or(existing.field_type);
+            let options = input.options.or(existing.options);
+            let position = input.position.unwrap_or(existing.position);
+
+            sqlx::query(
+                "UPDATE custom_fields SET name = ?, field_type = ?, options = ?, position = ? WHERE id = ?",
+            )
+            .bind(&name)
+            .bind(&field_type)
+            .bind(&options)
+            .bind(position)
+            .bind(id)
+            .execute(&state.pool)
+            .await?;
+
+            sqlx::query_as::<_, CustomField>("SELECT * FROM custom_fields WHERE id = ?")
+                .bind(id)
+                .fetch_one(&state.pool)
+                .await
+        })
+        .map_err(|e: sqlx::Error| e.to_string())
+}
+
+#[tauri::command]
+pub fn delete_custom_field(state: State<AppState>, id: i64) -> Result<(), String> {
+    state
+        .rt
+        .block_on(async {
+            let result = sqlx::query("DELETE FROM custom_fields WHERE id = ?")
+                .bind(id)
+                .execute(&state.pool)
+                .await?;
+            if result.rows_affected() == 0 {
+                return Err(sqlx::Error::RowNotFound);
+            }
+            Ok(())
+        })
+        .map_err(|e: sqlx::Error| e.to_string())
+}
+
+#[tauri::command]
+pub fn get_issue_custom_values(
+    state: State<AppState>,
+    issue_id: i64,
+) -> Result<Vec<CustomFieldValue>, String> {
+    state
+        .rt
+        .block_on(async {
+            sqlx::query_as::<_, CustomFieldValue>(
+                "SELECT * FROM issue_custom_field_values WHERE issue_id = ?",
+            )
+            .bind(issue_id)
+            .fetch_all(&state.pool)
+            .await
+        })
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn set_issue_custom_value(
+    state: State<AppState>,
+    issue_id: i64,
+    field_id: i64,
+    value: Option<String>,
+) -> Result<(), String> {
+    state
+        .rt
+        .block_on(async {
+            sqlx::query(
+                "INSERT INTO issue_custom_field_values (issue_id, field_id, value) VALUES (?, ?, ?) ON CONFLICT(issue_id, field_id) DO UPDATE SET value = excluded.value",
+            )
+            .bind(issue_id)
+            .bind(field_id)
+            .bind(&value)
+            .execute(&state.pool)
+            .await?;
+            Ok(())
+        })
+        .map_err(|e: sqlx::Error| e.to_string())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod comments;
+pub mod custom_fields;
 pub mod health;
 pub mod issues;
 pub mod labels;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -79,6 +79,13 @@ pub fn run() {
             commands::comments::update_comment,
             commands::comments::delete_comment,
             commands::comments::comment_count,
+            // Custom Fields
+            commands::custom_fields::list_custom_fields,
+            commands::custom_fields::create_custom_field,
+            commands::custom_fields::update_custom_field,
+            commands::custom_fields::delete_custom_field,
+            commands::custom_fields::get_issue_custom_values,
+            commands::custom_fields::set_issue_custom_value,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -168,3 +168,21 @@ pub struct Comment {
     pub created_at: String,
     pub updated_at: String,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct CustomField {
+    pub id: i64,
+    pub project_id: i64,
+    pub name: String,
+    pub field_type: String,
+    pub options: Option<String>,
+    pub position: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct CustomFieldValue {
+    pub id: i64,
+    pub issue_id: i64,
+    pub field_id: i64,
+    pub value: Option<String>,
+}

--- a/src/components/IssueDetailPanel.tsx
+++ b/src/components/IssueDetailPanel.tsx
@@ -3,7 +3,7 @@ import { X, Copy, Trash2, Pencil, AlertCircle, SignalHigh, SignalMedium, SignalL
 import { cn } from "@/lib/utils";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import type { Issue, IssueWithLabels, Status, Member, Label, ActivityLogEntry, Comment } from "@/types";
+import type { Issue, IssueWithLabels, Status, Member, Label, ActivityLogEntry, Comment, CustomField, CustomFieldValue } from "@/types";
 import * as api from "@/tauri/commands";
 
 interface IssueDetailPanelProps {
@@ -51,6 +51,8 @@ export function IssueDetailPanel({
   const [newComment, setNewComment] = useState("");
   const [editingCommentId, setEditingCommentId] = useState<number | null>(null);
   const [editingCommentContent, setEditingCommentContent] = useState("");
+  const [customFields, setCustomFields] = useState<CustomField[]>([]);
+  const [customValues, setCustomValues] = useState<CustomFieldValue[]>([]);
 
   useEffect(() => {
     loadIssue();
@@ -68,6 +70,10 @@ export function IssueDetailPanel({
       setSubIssues(subs);
       const comms = await api.listComments(issueId);
       setComments(comms);
+      const fields = await api.listCustomFields(data.project_id);
+      setCustomFields(fields);
+      const vals = await api.getIssueCustomValues(issueId);
+      setCustomValues(vals);
     } catch (e) {
       console.error("Failed to load issue", e);
     }
@@ -310,6 +316,102 @@ export function IssueDetailPanel({
             />
           </div>
         </div>
+
+        {/* Custom Fields */}
+        {customFields.length > 0 && (
+          <div className="mt-4 space-y-3 px-4">
+            <h3 className="text-xs font-medium text-muted-foreground">Custom Fields</h3>
+            {customFields.map((field) => {
+              const cv = customValues.find((v) => v.field_id === field.id);
+              const currentValue = cv?.value ?? "";
+              return (
+                <div key={field.id} className="flex items-center gap-3 text-sm">
+                  <span className="w-20 text-muted-foreground truncate" title={field.name}>
+                    {field.name}
+                  </span>
+                  {field.field_type === "select" ? (
+                    <select
+                      value={currentValue}
+                      onChange={async (e) => {
+                        const val = e.target.value || null;
+                        await api.setIssueCustomValue(issueId, field.id, val);
+                        await loadIssue();
+                      }}
+                      className="rounded bg-transparent px-2 py-1 text-sm outline-none hover:bg-accent"
+                    >
+                      <option value="">None</option>
+                      {(() => {
+                        try {
+                          const opts: string[] = JSON.parse(field.options || "[]");
+                          return opts.map((o) => (
+                            <option key={o} value={o}>
+                              {o}
+                            </option>
+                          ));
+                        } catch {
+                          return null;
+                        }
+                      })()}
+                    </select>
+                  ) : field.field_type === "date" ? (
+                    <input
+                      type="date"
+                      value={currentValue}
+                      onChange={async (e) => {
+                        const val = e.target.value || null;
+                        await api.setIssueCustomValue(issueId, field.id, val);
+                        await loadIssue();
+                      }}
+                      className="rounded bg-transparent px-2 py-1 text-sm outline-none hover:bg-accent"
+                    />
+                  ) : field.field_type === "number" ? (
+                    <input
+                      type="number"
+                      value={currentValue}
+                      onBlur={async (e) => {
+                        const val = e.target.value || null;
+                        await api.setIssueCustomValue(issueId, field.id, val);
+                        await loadIssue();
+                      }}
+                      onChange={(e) => {
+                        setCustomValues((prev) =>
+                          prev.some((v) => v.field_id === field.id)
+                            ? prev.map((v) =>
+                                v.field_id === field.id ? { ...v, value: e.target.value } : v
+                              )
+                            : [...prev, { id: 0, issue_id: issueId, field_id: field.id, value: e.target.value }]
+                        );
+                      }}
+                      placeholder="0"
+                      className="w-24 rounded bg-transparent px-2 py-1 text-sm outline-none hover:bg-accent"
+                    />
+                  ) : (
+                    <input
+                      type="text"
+                      value={currentValue}
+                      onBlur={async (e) => {
+                        const val = e.target.value || null;
+                        await api.setIssueCustomValue(issueId, field.id, val);
+                        await loadIssue();
+                      }}
+                      onChange={(e) => {
+                        setCustomValues((prev) =>
+                          prev.some((v) => v.field_id === field.id)
+                            ? prev.map((v) =>
+                                v.field_id === field.id ? { ...v, value: e.target.value } : v
+                              )
+                            : [...prev, { id: 0, issue_id: issueId, field_id: field.id, value: e.target.value }]
+                        );
+                      }}
+                      placeholder="Enter value..."
+                      className="flex-1 rounded bg-transparent px-2 py-1 text-sm outline-none hover:bg-accent"
+                    />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
 
         {/* Description */}
         <div className="mt-6 border-t border-border px-4 pt-4">

--- a/src/tauri/commands.ts
+++ b/src/tauri/commands.ts
@@ -12,6 +12,8 @@ import type {
   UndoLogEntry,
   Notification,
   Comment,
+  CustomField,
+  CustomFieldValue,
 } from "@/types";
 
 // Health
@@ -181,3 +183,26 @@ export const updateComment = (id: number, input: {
 }) => invoke<Comment>("update_comment", { id, input });
 export const deleteComment = (id: number) => invoke<void>("delete_comment", { id });
 export const commentCount = (issueId: number) => invoke<number>("comment_count", { issueId });
+
+// Custom Fields
+export const listCustomFields = (projectId: number) =>
+  invoke<CustomField[]>("list_custom_fields", { projectId });
+export const createCustomField = (input: {
+  project_id: number;
+  name: string;
+  field_type?: string;
+  options?: string;
+  position?: number;
+}) => invoke<CustomField>("create_custom_field", { input });
+export const updateCustomField = (id: number, input: {
+  name?: string;
+  field_type?: string;
+  options?: string;
+  position?: number;
+}) => invoke<CustomField>("update_custom_field", { id, input });
+export const deleteCustomField = (id: number) =>
+  invoke<void>("delete_custom_field", { id });
+export const getIssueCustomValues = (issueId: number) =>
+  invoke<CustomFieldValue[]>("get_issue_custom_values", { issueId });
+export const setIssueCustomValue = (issueId: number, fieldId: number, value: string | null) =>
+  invoke<void>("set_issue_custom_value", { issueId, fieldId, value });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -126,3 +126,19 @@ export interface Notification {
   read: boolean;
   created_at: string;
 }
+
+export interface CustomField {
+  id: number;
+  project_id: number;
+  name: string;
+  field_type: "text" | "number" | "date" | "select";
+  options: string | null;
+  position: number;
+}
+
+export interface CustomFieldValue {
+  id: number;
+  issue_id: number;
+  field_id: number;
+  value: string | null;
+}


### PR DESCRIPTION
Add database migration, Rust backend commands, frontend types/API, and UI in IssueDetailPanel for custom fields (text, number, date, select) on issues.