### PR TITLE
v2: Spec #3 — Kanban MCP Server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Kanban — Project Brain
 
-Local-first project management. v1 covers projects, issues, labels, default statuses, search, sort, undo/redo, and JSON I/O via a Rust core library and CLI. GUI (Tauri), MCP server, and AI-agent orchestration ship in later specs.
+Local-first project management. v1 covers projects, issues, labels, default statuses, search, sort, undo/redo, and JSON I/O via a Rust core library and CLI. The GUI (Tauri, Spec #2) and the MCP server (Spec #3) have shipped; AI-agent orchestration follows in later specs.
 
 ## Stack
 
@@ -40,9 +40,19 @@ The GUI is `crates/kanban-tauri` (Rust shell) + `ui/` (Vite + React 19 + Tailwin
 - **`workspace_settings`** (migration `0002`) stores app-level prefs (theme) via `Workspace::get_setting`/`set_setting` — a **documented exception** to the single-mutator invariant; settings have no undo semantics.
 - **DTOs, not core types, cross the bridge.** `kanban-tauri/src/dto.rs` defines specta `Type` DTOs (`ProjectDto`, `IssueDto`, …) with ids/dates/enums as strings; core types stay specta-free.
 - **`tauri-specta` generates `ui/src/data/bindings.ts`** (git-tracked) via the `export_bindings` test; CI fails on drift. `specta-typescript` is configured with `BigIntExportBehavior::Number` so `i64` fields become TS `number`.
-- **No live cross-process watcher.** The GUI refetches on window focus (`refetchOnWindowFocus`); a SQLite `update_hook` watcher is deferred to Spec #3.
-- **E2E (`tauri-driver`) is deferred to Spec #3** (no macOS WebDriver support); Spec #2 ships Vitest + RTL coverage. See `ui/e2e/README.md`.
+- **No live cross-process watcher.** The GUI refetches on window focus (`refetchOnWindowFocus`); a SQLite `update_hook` watcher is deferred to a later spec.
+- **E2E (`tauri-driver`) is deferred to a later spec** (no macOS WebDriver support); Spec #2 ships Vitest + RTL coverage. See `ui/e2e/README.md`.
 - **UI tooling on Apple Silicon:** if the default `node` is x86_64 (nvm), run ui scripts under a native arm64 node (`PATH="/opt/homebrew/bin:$PATH" npx pnpm@9.12.0 …`) or rollup/esbuild crash. See `DEVELOPMENT.md`.
+
+## MCP layer (Spec #3)
+
+The MCP server is `crates/kanban-mcp` — a stdio server (on `rmcp`) exposing `kanban-core` to AI assistants (Claude Desktop/Code). Design: `docs/superpowers/specs/2026-06-05-kanban-v2-spec-3-mcp-server-design.md`.
+
+- Opens the default workspace (`Workspace::open_default`) — shares `~/.kanban/data.db` with the CLI and GUI (SQLite WAL, multi-process safe).
+- Each async `#[tool]` runs the sync core inside `tokio::task::spawn_blocking` over an `Arc<Mutex<Workspace>>` (the `blocking_read`/`blocking_mut` helpers); the guard never crosses `.await`. **Writes go through `Workspace::apply`** — single-mutator invariant preserved.
+- **Semantic tools**, not a generic apply: reads (`list_projects`, `list_statuses`, `list_labels`, `list_issues`, `get_issue`, `search_issues`) + writes (`create_project`, `create_issue`, `update_issue`, `move_issue`, `undo`, `redo`). Tools resolve human identifiers — project `prefix`, issue `key`, status/label `name` — to core UUIDs; misses map to `not_found`/`unknown_name` MCP errors. Output DTOs (`convert.rs`) are human-facing (no UUIDs/sort_keys).
+- Resolution uses the existing unique indexes via `Workspace::query_project_by_prefix`/`query_issue_by_identifier` (no new migration). `move_issue` computes a fractional sort-key midpoint (1024-gap, like the GUI). Tested per-tool over an in-process `tokio::io::duplex` transport.
+- **Agent orchestration (registry, task contracts, decomposition, validation) is deferred to Spec #4+.**
 
 ## TDD discipline
 
@@ -78,7 +88,9 @@ These don't block v1 but should be addressed before broader release:
 
 ## Spec/plan trail
 
-- `docs/superpowers/specs/2026-05-03-kanban-v2-core-cli-design.md` — the v1 design.
+- `docs/superpowers/specs/2026-05-03-kanban-v2-core-cli-design.md` — the v1 (core + CLI) design.
 - `docs/superpowers/plans/2026-05-03-kanban-v2-core-cli-plan.md` — the 41-task TDD plan that built it.
+- `docs/superpowers/specs/2026-05-05-kanban-v2-spec-2-gui-shell-design.md` — Spec #2 (Tauri GUI shell).
+- `docs/superpowers/specs/2026-06-05-kanban-v2-spec-3-mcp-server-design.md` — Spec #3 (MCP server).
 
-Future specs (GUI, MCP, AI-agent orchestration) live alongside in `docs/superpowers/specs/`.
+Each spec has a matching plan in `docs/superpowers/plans/`. AI-agent orchestration (Spec #4+) will live alongside.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,12 +1022,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1071,6 +1098,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1887,6 +1915,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "kanban-mcp"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "kanban-core",
+ "rmcp",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "kanban-tauri"
 version = "0.0.1"
 dependencies = [
@@ -1917,6 +1961,12 @@ dependencies = [
  "serde",
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -2032,6 +2082,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2123,6 +2182,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-conv"
@@ -2449,6 +2517,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pathdiff"
@@ -2898,6 +2972,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2975,7 +3085,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
  "url",
@@ -3000,8 +3110,10 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -3011,6 +3123,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3220,6 +3344,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -3910,6 +4043,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3975,6 +4117,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -3989,6 +4132,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -4176,7 +4330,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4186,6 +4352,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -4347,6 +4543,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,6 +1928,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1919,6 +1919,7 @@ name = "kanban-mcp"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "chrono",
  "kanban-core",
  "rmcp",
  "schemars 1.2.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/kanban-core", "crates/kanban-cli", "crates/kanban-tauri"]
+members = ["crates/kanban-core", "crates/kanban-cli", "crates/kanban-tauri", "crates/kanban-mcp"]
 
 [workspace.package]
 edition = "2024"
@@ -40,5 +40,11 @@ tauri-build = { version = "2", features = [] }
 tauri-specta = { version = "2.0.0-rc.21", features = ["derive", "typescript"] }
 specta = { version = "2.0.0-rc.22", features = ["derive", "serde_json"] }
 specta-typescript = "0.0.9"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "io-std", "io-util", "signal"] }
 tauri-plugin-shell = "2"
+
+# new for kanban-mcp
+rmcp = { version = "1", features = ["server", "macros", "transport-io"] }
+schemars = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -82,4 +82,46 @@ The first ship is unsigned. A downloaded `.app` may be quarantined on macOS:
 xattr -dr com.apple.quarantine /Applications/kanban.app
 ```
 
-Apple Developer signing lands in Spec #3.
+Apple Developer signing lands in a later spec.
+
+## MCP server (Spec #3)
+
+`crates/kanban-mcp` is a stdio MCP server (built on [`rmcp`](https://crates.io/crates/rmcp))
+exposing `kanban-core` to AI assistants. It opens the default workspace
+(`~/.kanban/data.db`, or `$KANBAN_DB`) — the same DB as the CLI and GUI — and
+serves these tools: `list_projects`, `list_statuses`, `list_labels`,
+`list_issues`, `get_issue`, `search_issues`, `create_project`, `create_issue`,
+`update_issue`, `move_issue`, `undo`, `redo`. Projects are addressed by prefix
+(`AUTH`), issues by key (`AUTH-12`), statuses/labels by name. Every write goes
+through `Workspace::apply`.
+
+```sh
+cargo build -p kanban-mcp --release   # target/release/kanban-mcp
+cargo test -p kanban-mcp              # unit + in-process stdio integration tests
+```
+
+### Register with Claude Desktop
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "kanban": {
+      "command": "/absolute/path/to/target/release/kanban-mcp",
+      "env": { "KANBAN_DB": "/Users/you/.kanban/data.db" }
+    }
+  }
+}
+```
+
+(`KANBAN_DB` is optional — it defaults to `~/.kanban/data.db`.)
+
+### Register with Claude Code
+
+```sh
+claude mcp add kanban -- /absolute/path/to/target/release/kanban-mcp
+```
+
+or add the equivalent entry to `.mcp.json`. The server logs to stderr (stdout is
+the JSON-RPC channel).

--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ Projects and issues created from the CLI appear in the GUI after its window
 receives focus (the board refetches on focus; there is no live cross-process
 watcher yet).
 
+## Use from an AI assistant (MCP)
+
+`kanban-mcp` is a stdio [MCP](https://modelcontextprotocol.io) server that lets an
+AI assistant (Claude Desktop, Claude Code) read and manage your board in natural
+language — list/create/update/move issues, search, undo. It shares the same
+`~/.kanban/data.db` as the CLI and GUI.
+
+```sh
+cargo build -p kanban-mcp --release   # binary at target/release/kanban-mcp
+```
+
+Register it with your client (see `DEVELOPMENT.md`), then ask the assistant to,
+e.g., "create a project AUTH and add an issue to implement OAuth login."
+
 ## Development
 
-See `DEVELOPMENT.md` for build, test, and contribution conventions (CLI and GUI).
+See `DEVELOPMENT.md` for build, test, and contribution conventions (CLI, GUI, MCP).

--- a/crates/kanban-core/src/workspace.rs
+++ b/crates/kanban-core/src/workspace.rs
@@ -127,6 +127,60 @@ impl Workspace {
         crate::store::read::issues::by_id(&self.conn, id)
     }
 
+    /// Look up a project by its unique `prefix`. Returns `Ok(None)` if absent.
+    ///
+    /// # Errors
+    ///
+    /// Returns a database error if the read fails.
+    pub fn query_project_by_prefix(
+        &self,
+        prefix: &str,
+    ) -> crate::error::Result<Option<crate::types::Project>> {
+        use rusqlite::OptionalExtension;
+        let id: Option<uuid::Uuid> = self
+            .conn
+            .query_row(
+                "SELECT id FROM projects WHERE prefix = ?1",
+                [prefix],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+            .map(|s| uuid::Uuid::parse_str(&s))
+            .transpose()
+            .map_err(|e| crate::error::Error::InvalidSnapshot(format!("bad project uuid: {e}")))?;
+        match id {
+            Some(id) => Ok(Some(self.query_project_by_id(id)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Look up an issue by its unique `identifier` (e.g. `AUTH-12`). Returns `Ok(None)` if absent.
+    ///
+    /// # Errors
+    ///
+    /// Returns a database error if the read fails.
+    pub fn query_issue_by_identifier(
+        &self,
+        identifier: &str,
+    ) -> crate::error::Result<Option<crate::types::Issue>> {
+        use rusqlite::OptionalExtension;
+        let id: Option<uuid::Uuid> = self
+            .conn
+            .query_row(
+                "SELECT id FROM issues WHERE identifier = ?1",
+                [identifier],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+            .map(|s| uuid::Uuid::parse_str(&s))
+            .transpose()
+            .map_err(|e| crate::error::Error::InvalidSnapshot(format!("bad issue uuid: {e}")))?;
+        match id {
+            Some(id) => Ok(Some(self.query_issue_by_id(id)?)),
+            None => Ok(None),
+        }
+    }
+
     /// List issues matching `filter`, ordered as the filter directs.
     ///
     /// # Errors

--- a/crates/kanban-core/tests/resolution.rs
+++ b/crates/kanban-core/tests/resolution.rs
@@ -1,0 +1,57 @@
+#![allow(clippy::unwrap_used)]
+use kanban_core::Workspace;
+use kanban_core::operation::{CreateProject, Operation};
+use uuid::Uuid;
+
+#[test]
+fn project_by_prefix_hit_and_miss() {
+    let mut ws = Workspace::open_in_memory().unwrap();
+    let id = Uuid::now_v7();
+    ws.apply(Operation::CreateProject(CreateProject {
+        id,
+        name: "Auth Service".into(),
+        prefix: "AUTH".into(),
+        description: None,
+        icon: None,
+    }))
+    .unwrap();
+
+    let hit = ws.query_project_by_prefix("AUTH").unwrap();
+    assert_eq!(hit.map(|p| p.id), Some(id));
+    assert!(ws.query_project_by_prefix("NOPE").unwrap().is_none());
+}
+
+#[test]
+fn issue_by_identifier_hit_and_miss() {
+    use kanban_core::operation::CreateIssue;
+    use kanban_core::types::Priority;
+
+    let mut ws = Workspace::open_in_memory().unwrap();
+    let pid = Uuid::now_v7();
+    ws.apply(Operation::CreateProject(CreateProject {
+        id: pid,
+        name: "Auth".into(),
+        prefix: "AUTH".into(),
+        description: None,
+        icon: None,
+    }))
+    .unwrap();
+    let status_id = ws.query_statuses_for_project(pid).unwrap()[0].id;
+
+    let iid = Uuid::now_v7();
+    ws.apply(Operation::CreateIssue(CreateIssue {
+        id: iid,
+        project_id: pid,
+        title: "Add OAuth".into(),
+        description: None,
+        status_id,
+        priority: Priority::Medium,
+        due_date: None,
+        label_ids: vec![],
+    }))
+    .unwrap();
+
+    let issue = ws.query_issue_by_identifier("AUTH-1").unwrap();
+    assert_eq!(issue.map(|i| i.id), Some(iid));
+    assert!(ws.query_issue_by_identifier("AUTH-999").unwrap().is_none());
+}

--- a/crates/kanban-mcp/Cargo.toml
+++ b/crates/kanban-mcp/Cargo.toml
@@ -26,5 +26,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
-rmcp = { version = "1", features = ["server", "macros", "transport-io", "client"] }
+# Inherit the workspace rmcp (server/macros/transport-io) + add the client
+# feature for the in-process integration tests.
+rmcp = { workspace = true, features = ["client"] }
 tempfile = { workspace = true }

--- a/crates/kanban-mcp/Cargo.toml
+++ b/crates/kanban-mcp/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 
 [dependencies]
 kanban-core = { path = "../kanban-core" }
+chrono = { workspace = true }
 uuid = { workspace = true }
 rmcp = { workspace = true }
 schemars = { workspace = true }

--- a/crates/kanban-mcp/Cargo.toml
+++ b/crates/kanban-mcp/Cargo.toml
@@ -10,6 +10,10 @@ description = "Stdio MCP server exposing kanban-core to AI assistants."
 [lints]
 workspace = true
 
+[lib]
+name = "kanban_mcp"
+path = "src/lib.rs"
+
 [[bin]]
 name = "kanban-mcp"
 path = "src/main.rs"
@@ -30,3 +34,4 @@ tracing-subscriber = { workspace = true }
 # feature for the in-process integration tests.
 rmcp = { workspace = true, features = ["client"] }
 tempfile = { workspace = true }
+uuid = { workspace = true }

--- a/crates/kanban-mcp/Cargo.toml
+++ b/crates/kanban-mcp/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 
 [dependencies]
 kanban-core = { path = "../kanban-core" }
+uuid = { workspace = true }
 rmcp = { workspace = true }
 schemars = { workspace = true }
 tokio = { workspace = true }

--- a/crates/kanban-mcp/Cargo.toml
+++ b/crates/kanban-mcp/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "kanban-mcp"
+version = "0.0.1"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Stdio MCP server exposing kanban-core to AI assistants."
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "kanban-mcp"
+path = "src/main.rs"
+
+[dependencies]
+kanban-core = { path = "../kanban-core" }
+rmcp = { workspace = true }
+schemars = { workspace = true }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+rmcp = { version = "1", features = ["server", "macros", "transport-io", "client"] }
+tempfile = { workspace = true }

--- a/crates/kanban-mcp/src/convert.rs
+++ b/crates/kanban-mcp/src/convert.rs
@@ -1,7 +1,16 @@
 //! Output shapes returned to the MCP client. Human-facing: prefixes/keys/names,
 //! never UUIDs or sort keys.
+use std::collections::HashMap;
+
 use kanban_core::types::{Issue, Label, Project, Status};
 use serde::Serialize;
+use uuid::Uuid;
+
+/// Map status id -> status name for a project's statuses.
+#[must_use]
+pub fn status_name_map(statuses: &[Status]) -> HashMap<Uuid, String> {
+    statuses.iter().map(|s| (s.id, s.name.clone())).collect()
+}
 
 #[derive(Serialize)]
 pub struct ProjectOut {
@@ -47,8 +56,6 @@ impl From<Label> for LabelOut {
     }
 }
 
-// `IssueOut` is consumed by the issue tools in Task 6; allow dead_code until then.
-#[allow(dead_code)]
 #[derive(Serialize)]
 pub struct IssueOut {
     pub key: String,
@@ -61,7 +68,6 @@ pub struct IssueOut {
 
 impl IssueOut {
     /// Build from a core `Issue` plus a resolved status NAME.
-    #[allow(dead_code)]
     #[must_use]
     pub fn from_issue(i: Issue, status_name: &str) -> Self {
         Self {

--- a/crates/kanban-mcp/src/convert.rs
+++ b/crates/kanban-mcp/src/convert.rs
@@ -1,8 +1,5 @@
 //! Output shapes returned to the MCP client. Human-facing: prefixes/keys/names,
 //! never UUIDs or sort keys.
-// `StatusOut`/`LabelOut`/`IssueOut` are consumed by the issue/label tools in
-// Tasks 5-6; allow dead_code until then. Remove this once they are wired up.
-#![allow(dead_code)]
 use kanban_core::types::{Issue, Label, Project, Status};
 use serde::Serialize;
 
@@ -50,6 +47,8 @@ impl From<Label> for LabelOut {
     }
 }
 
+// `IssueOut` is consumed by the issue tools in Task 6; allow dead_code until then.
+#[allow(dead_code)]
 #[derive(Serialize)]
 pub struct IssueOut {
     pub key: String,
@@ -62,6 +61,7 @@ pub struct IssueOut {
 
 impl IssueOut {
     /// Build from a core `Issue` plus a resolved status NAME.
+    #[allow(dead_code)]
     #[must_use]
     pub fn from_issue(i: Issue, status_name: &str) -> Self {
         Self {

--- a/crates/kanban-mcp/src/convert.rs
+++ b/crates/kanban-mcp/src/convert.rs
@@ -1,0 +1,76 @@
+//! Output shapes returned to the MCP client. Human-facing: prefixes/keys/names,
+//! never UUIDs or sort keys.
+// `StatusOut`/`LabelOut`/`IssueOut` are consumed by the issue/label tools in
+// Tasks 5-6; allow dead_code until then. Remove this once they are wired up.
+#![allow(dead_code)]
+use kanban_core::types::{Issue, Label, Project, Status};
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct ProjectOut {
+    pub prefix: String,
+    pub name: String,
+    pub description: Option<String>,
+}
+impl From<Project> for ProjectOut {
+    fn from(p: Project) -> Self {
+        Self {
+            prefix: p.prefix,
+            name: p.name,
+            description: p.description,
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct StatusOut {
+    pub name: String,
+    pub category: String,
+}
+impl From<Status> for StatusOut {
+    fn from(s: Status) -> Self {
+        Self {
+            name: s.name,
+            category: s.category.as_str().to_owned(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct LabelOut {
+    pub name: String,
+    pub color: String,
+}
+impl From<Label> for LabelOut {
+    fn from(l: Label) -> Self {
+        Self {
+            name: l.name,
+            color: l.color,
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct IssueOut {
+    pub key: String,
+    pub title: String,
+    pub status: String,
+    pub priority: String,
+    pub due_date: Option<String>,
+    pub description: Option<String>,
+}
+
+impl IssueOut {
+    /// Build from a core `Issue` plus a resolved status NAME.
+    #[must_use]
+    pub fn from_issue(i: Issue, status_name: &str) -> Self {
+        Self {
+            key: i.identifier,
+            title: i.title,
+            status: status_name.to_owned(),
+            priority: i.priority.as_str().to_owned(),
+            due_date: i.due_date.map(|d| d.to_string()),
+            description: i.description,
+        }
+    }
+}

--- a/crates/kanban-mcp/src/error.rs
+++ b/crates/kanban-mcp/src/error.rs
@@ -27,7 +27,7 @@ pub fn not_found(resource: &str, key: &str) -> McpError {
 }
 
 /// A "name not found within a project" error that lists the valid options.
-#[allow(dead_code)] // consumed by the resolution tools from Task 5 onward
+/// Used by `list_issues` to resolve a status name within a project.
 #[must_use]
 pub fn unknown_name(kind: &str, name: &str, project: &str, available: &[String]) -> McpError {
     McpError::invalid_params(

--- a/crates/kanban-mcp/src/error.rs
+++ b/crates/kanban-mcp/src/error.rs
@@ -1,7 +1,4 @@
 //! Map kanban-core errors (and resolution misses) to MCP tool errors.
-// `not_found`/`unknown_name` are consumed by the resolution tools from Task 5
-// onward; `to_mcp` is used by the server now.
-#![allow(dead_code)]
 use rmcp::ErrorData as McpError;
 
 /// Convert a `kanban_core::Error` into an MCP tool error with an LLM-actionable message.
@@ -24,12 +21,14 @@ pub fn to_mcp(err: kanban_core::Error) -> McpError {
 }
 
 /// A "not found by human identifier" error (project prefix / issue key).
+#[allow(dead_code)] // consumed by the resolution tools from Task 5 onward
 #[must_use]
 pub fn not_found(resource: &str, key: &str) -> McpError {
     McpError::resource_not_found(format!("{resource} not found: {key}"), None)
 }
 
 /// A "name not found within a project" error that lists the valid options.
+#[allow(dead_code)] // consumed by the resolution tools from Task 5 onward
 #[must_use]
 pub fn unknown_name(kind: &str, name: &str, project: &str, available: &[String]) -> McpError {
     McpError::invalid_params(

--- a/crates/kanban-mcp/src/error.rs
+++ b/crates/kanban-mcp/src/error.rs
@@ -1,9 +1,11 @@
 //! Map kanban-core errors (and resolution misses) to MCP tool errors.
-// consumed by the server tools from Task 4 onward
+// `not_found`/`unknown_name` are consumed by the resolution tools from Task 5
+// onward; `to_mcp` is used by the server now.
 #![allow(dead_code)]
 use rmcp::ErrorData as McpError;
 
 /// Convert a `kanban_core::Error` into an MCP tool error with an LLM-actionable message.
+#[must_use]
 pub fn to_mcp(err: kanban_core::Error) -> McpError {
     use kanban_core::Error;
     match err {
@@ -22,11 +24,13 @@ pub fn to_mcp(err: kanban_core::Error) -> McpError {
 }
 
 /// A "not found by human identifier" error (project prefix / issue key).
+#[must_use]
 pub fn not_found(resource: &str, key: &str) -> McpError {
     McpError::resource_not_found(format!("{resource} not found: {key}"), None)
 }
 
 /// A "name not found within a project" error that lists the valid options.
+#[must_use]
 pub fn unknown_name(kind: &str, name: &str, project: &str, available: &[String]) -> McpError {
     McpError::invalid_params(
         format!(

--- a/crates/kanban-mcp/src/error.rs
+++ b/crates/kanban-mcp/src/error.rs
@@ -1,0 +1,64 @@
+//! Map kanban-core errors (and resolution misses) to MCP tool errors.
+// consumed by the server tools from Task 4 onward
+#![allow(dead_code)]
+use rmcp::ErrorData as McpError;
+
+/// Convert a `kanban_core::Error` into an MCP tool error with an LLM-actionable message.
+pub fn to_mcp(err: kanban_core::Error) -> McpError {
+    use kanban_core::Error;
+    match err {
+        Error::NotFound { kind, id } => {
+            McpError::resource_not_found(format!("{kind} not found: {id}"), None)
+        }
+        Error::Validation(v) => {
+            McpError::invalid_params(format!("{}: {}", v.field, v.reason), None)
+        }
+        Error::Conflict(msg) => McpError::invalid_request(msg, None),
+        Error::Db(e) => McpError::internal_error(format!("db: {e}"), None),
+        Error::Io(e) => McpError::internal_error(format!("io: {e}"), None),
+        Error::Serde(e) => McpError::internal_error(format!("serde: {e}"), None),
+        Error::InvalidSnapshot(s) => McpError::invalid_params(format!("snapshot: {s}"), None),
+    }
+}
+
+/// A "not found by human identifier" error (project prefix / issue key).
+pub fn not_found(resource: &str, key: &str) -> McpError {
+    McpError::resource_not_found(format!("{resource} not found: {key}"), None)
+}
+
+/// A "name not found within a project" error that lists the valid options.
+pub fn unknown_name(kind: &str, name: &str, project: &str, available: &[String]) -> McpError {
+    McpError::invalid_params(
+        format!(
+            "{kind} '{name}' not found in project {project}; available: {}",
+            available.join(", ")
+        ),
+        None,
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validation_maps_to_invalid_params_with_field() {
+        let err = kanban_core::Error::Validation(kanban_core::ValidationError {
+            field: "prefix".into(),
+            reason: "must be 2-8 uppercase letters".into(),
+        });
+        let mcp = to_mcp(err);
+        let rendered = format!("{mcp:?}");
+        assert!(rendered.contains("prefix"), "got: {rendered}");
+        assert!(rendered.contains("uppercase"), "got: {rendered}");
+    }
+
+    #[test]
+    fn unknown_name_lists_available() {
+        let mcp = unknown_name("status", "Doing", "AUTH", &["To Do".into(), "Done".into()]);
+        let rendered = format!("{mcp:?}");
+        assert!(rendered.contains("Doing"), "got: {rendered}");
+        assert!(rendered.contains("To Do, Done"), "got: {rendered}");
+    }
+}

--- a/crates/kanban-mcp/src/error.rs
+++ b/crates/kanban-mcp/src/error.rs
@@ -21,7 +21,6 @@ pub fn to_mcp(err: kanban_core::Error) -> McpError {
 }
 
 /// A "not found by human identifier" error (project prefix / issue key).
-#[allow(dead_code)] // consumed by the resolution tools from Task 5 onward
 #[must_use]
 pub fn not_found(resource: &str, key: &str) -> McpError {
     McpError::resource_not_found(format!("{resource} not found: {key}"), None)

--- a/crates/kanban-mcp/src/inputs.rs
+++ b/crates/kanban-mcp/src/inputs.rs
@@ -41,6 +41,26 @@ pub struct CreateProjectInput {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct CreateIssueInput {
+    /// Project prefix, e.g. "AUTH".
+    pub project: String,
+    /// Issue title.
+    pub title: String,
+    /// Optional markdown description.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Optional status name; defaults to the project's first column.
+    #[serde(default)]
+    pub status: Option<String>,
+    /// Optional priority: none, low, medium, high, urgent. Defaults to medium.
+    #[serde(default)]
+    pub priority: Option<String>,
+    /// Optional due date, YYYY-MM-DD.
+    #[serde(default)]
+    pub due_date: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct SearchIssues {
     /// Full-text query.
     pub query: String,

--- a/crates/kanban-mcp/src/inputs.rs
+++ b/crates/kanban-mcp/src/inputs.rs
@@ -82,6 +82,21 @@ pub struct UpdateIssueInput {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct MoveIssueInput {
+    /// Issue key to move, e.g. "AUTH-12".
+    pub key: String,
+    /// Optional target status name (e.g. "In Progress"). If omitted, the column is unchanged.
+    #[serde(default)]
+    pub status: Option<String>,
+    /// Optional sibling key: place the moved issue immediately BEFORE this issue.
+    #[serde(default)]
+    pub before: Option<String>,
+    /// Optional sibling key: place the moved issue immediately AFTER this issue.
+    #[serde(default)]
+    pub after: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct SearchIssues {
     /// Full-text query.
     pub query: String,

--- a/crates/kanban-mcp/src/inputs.rs
+++ b/crates/kanban-mcp/src/inputs.rs
@@ -1,2 +1,9 @@
 //! Tool input parameter structs (`serde::Deserialize` + `schemars::JsonSchema`).
-//! Populated as tools are added.
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ProjectRef {
+    /// Project prefix, e.g. "AUTH".
+    pub project: String,
+}

--- a/crates/kanban-mcp/src/inputs.rs
+++ b/crates/kanban-mcp/src/inputs.rs
@@ -7,3 +7,33 @@ pub struct ProjectRef {
     /// Project prefix, e.g. "AUTH".
     pub project: String,
 }
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListIssues {
+    /// Project prefix, e.g. "AUTH".
+    pub project: String,
+    /// Optional status name to filter by (e.g. "In Progress").
+    #[serde(default)]
+    pub status: Option<String>,
+    /// Optional priority filter: one of none, low, medium, high, urgent.
+    #[serde(default)]
+    pub priority: Option<String>,
+    /// Optional full-text search within the project.
+    #[serde(default)]
+    pub search: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct IssueKey {
+    /// Issue key, e.g. "AUTH-12".
+    pub key: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SearchIssues {
+    /// Full-text query.
+    pub query: String,
+    /// Optional project prefix to scope the search.
+    #[serde(default)]
+    pub project: Option<String>,
+}

--- a/crates/kanban-mcp/src/inputs.rs
+++ b/crates/kanban-mcp/src/inputs.rs
@@ -1,0 +1,2 @@
+//! Tool input parameter structs (`serde::Deserialize` + `schemars::JsonSchema`).
+//! Populated as tools are added.

--- a/crates/kanban-mcp/src/inputs.rs
+++ b/crates/kanban-mcp/src/inputs.rs
@@ -30,6 +30,17 @@ pub struct IssueKey {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct CreateProjectInput {
+    /// Display name, e.g. "Auth Service".
+    pub name: String,
+    /// Unique prefix: 2-8 uppercase letters, e.g. "AUTH".
+    pub prefix: String,
+    /// Optional description.
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct SearchIssues {
     /// Full-text query.
     pub query: String,

--- a/crates/kanban-mcp/src/inputs.rs
+++ b/crates/kanban-mcp/src/inputs.rs
@@ -61,6 +61,27 @@ pub struct CreateIssueInput {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct UpdateIssueInput {
+    /// Issue key, e.g. "AUTH-12".
+    pub key: String,
+    /// New title.
+    #[serde(default)]
+    pub title: Option<String>,
+    /// New markdown description (empty string clears the visible text).
+    #[serde(default)]
+    pub description: Option<String>,
+    /// New priority: none, low, medium, high, urgent.
+    #[serde(default)]
+    pub priority: Option<String>,
+    /// New status name (e.g. "In Progress").
+    #[serde(default)]
+    pub status: Option<String>,
+    /// New due date, YYYY-MM-DD.
+    #[serde(default)]
+    pub due_date: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct SearchIssues {
     /// Full-text query.
     pub query: String,

--- a/crates/kanban-mcp/src/lib.rs
+++ b/crates/kanban-mcp/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod convert;
+pub mod error;
+pub mod inputs;
+pub mod server;

--- a/crates/kanban-mcp/src/main.rs
+++ b/crates/kanban-mcp/src/main.rs
@@ -1,4 +1,6 @@
 //! Stdio MCP server for kanban-core. Real implementation lands in later tasks.
+mod error;
+
 fn main() {
     eprintln!("kanban-mcp: not yet implemented");
 }

--- a/crates/kanban-mcp/src/main.rs
+++ b/crates/kanban-mcp/src/main.rs
@@ -1,6 +1,20 @@
-//! Stdio MCP server for kanban-core. Real implementation lands in later tasks.
-mod error;
+use anyhow::Result;
+use rmcp::{ServiceExt, transport::stdio};
+use tracing_subscriber::EnvFilter;
 
-fn main() {
-    eprintln!("kanban-mcp: not yet implemented");
+use kanban_mcp::server::KanbanServer;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // stdout is the JSON-RPC channel — all logging goes to stderr.
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive(tracing::Level::INFO.into()))
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .init();
+
+    let server = KanbanServer::from_default()?;
+    let service = server.serve(stdio()).await?;
+    service.waiting().await?;
+    Ok(())
 }

--- a/crates/kanban-mcp/src/main.rs
+++ b/crates/kanban-mcp/src/main.rs
@@ -1,0 +1,4 @@
+//! Stdio MCP server for kanban-core. Real implementation lands in later tasks.
+fn main() {
+    eprintln!("kanban-mcp: not yet implemented");
+}

--- a/crates/kanban-mcp/src/server.rs
+++ b/crates/kanban-mcp/src/server.rs
@@ -404,6 +404,94 @@ impl KanbanServer {
         let name = map.get(&issue.status_id).cloned().unwrap_or_default();
         json_content(&crate::convert::IssueOut::from_issue(issue, &name))
     }
+
+    #[tool(
+        description = "Update fields of an issue (by key). Provide any of title, description, priority, status, due_date. Returns the updated issue."
+    )]
+    async fn update_issue(
+        &self,
+        Parameters(args): Parameters<crate::inputs::UpdateIssueInput>,
+    ) -> Result<CallToolResult, McpError> {
+        use kanban_core::operation::{IssueFieldChange, Operation, UpdateIssueField};
+        use kanban_core::types::Priority;
+
+        if args.title.is_none()
+            && args.description.is_none()
+            && args.priority.is_none()
+            && args.status.is_none()
+            && args.due_date.is_none()
+        {
+            return Err(McpError::invalid_params(
+                "provide at least one field to update (title, description, priority, status, due_date)",
+                None,
+            ));
+        }
+
+        // phase 1: resolve issue id + its project's statuses
+        let key = args.key.clone();
+        let resolved = self
+            .blocking_read(move |ws| {
+                let Some(issue) = ws.query_issue_by_identifier(&key)? else {
+                    return Ok(None);
+                };
+                let statuses = ws.query_statuses_for_project(issue.project_id)?;
+                Ok(Some((issue.id, statuses)))
+            })
+            .await?;
+        let (issue_id, statuses) =
+            resolved.ok_or_else(|| crate::error::not_found("issue", &args.key))?;
+
+        // phase 2: build the list of field changes (McpError resolution here)
+        let mut changes: Vec<IssueFieldChange> = Vec::new();
+        if let Some(t) = args.title {
+            changes.push(IssueFieldChange::Title(t));
+        }
+        if let Some(d) = args.description {
+            changes.push(IssueFieldChange::Description(Some(d)));
+        }
+        if let Some(p) = &args.priority {
+            let parsed: Priority = p.parse().map_err(|_| {
+                McpError::invalid_params(
+                    "priority must be one of none, low, medium, high, urgent",
+                    None,
+                )
+            })?;
+            changes.push(IssueFieldChange::Priority(parsed));
+        }
+        if let Some(name) = &args.status {
+            let s = statuses.iter().find(|s| &s.name == name).ok_or_else(|| {
+                crate::error::unknown_name(
+                    "status",
+                    name,
+                    &args.key,
+                    &statuses.iter().map(|s| s.name.clone()).collect::<Vec<_>>(),
+                )
+            })?;
+            changes.push(IssueFieldChange::Status(s.id));
+        }
+        if let Some(d) = &args.due_date {
+            let date = chrono::NaiveDate::parse_from_str(d, "%Y-%m-%d")
+                .map_err(|_| McpError::invalid_params("due_date must be YYYY-MM-DD", None))?;
+            changes.push(IssueFieldChange::DueDate(Some(date)));
+        }
+
+        // phase 3: apply each change, then re-read
+        let issue = self
+            .blocking_mut(move |ws| {
+                for change in changes {
+                    ws.apply(Operation::UpdateIssueField(UpdateIssueField {
+                        id: issue_id,
+                        change,
+                    }))?;
+                }
+                ws.query_issue_by_id(issue_id)
+            })
+            .await?;
+
+        let map = crate::convert::status_name_map(&statuses);
+        let name = map.get(&issue.status_id).cloned().unwrap_or_default();
+        json_content(&crate::convert::IssueOut::from_issue(issue, &name))
+    }
 }
 
 #[tool_handler]

--- a/crates/kanban-mcp/src/server.rs
+++ b/crates/kanban-mcp/src/server.rs
@@ -59,6 +59,25 @@ impl KanbanServer {
         .map_err(to_mcp)
     }
 
+    /// Run a mutating sync closure against the workspace on a blocking thread
+    /// (for `apply`/`undo`/`redo`). The mutex guard never crosses `.await`.
+    async fn blocking_mut<T, F>(&self, f: F) -> Result<T, McpError>
+    where
+        T: Send + 'static,
+        F: FnOnce(&mut Workspace) -> Result<T, kanban_core::Error> + Send + 'static,
+    {
+        let ws = Arc::clone(&self.workspace);
+        tokio::task::spawn_blocking(move || {
+            let mut guard = ws
+                .lock()
+                .map_err(|_| kanban_core::Error::Conflict("workspace mutex poisoned".into()))?;
+            f(&mut guard)
+        })
+        .await
+        .map_err(|e| McpError::internal_error(format!("task join error: {e}"), None))?
+        .map_err(to_mcp)
+    }
+
     /// Resolve a project's statuses + run a project-scoped read in one lock.
     /// `f(ws, project_id, &statuses)` yields the read result. An unknown prefix
     /// maps to a not-found error.
@@ -274,6 +293,28 @@ impl KanbanServer {
             })
             .collect();
         json_content(&out)
+    }
+
+    #[tool(description = "Create a new project. `prefix` must be 2-8 uppercase letters.")]
+    async fn create_project(
+        &self,
+        Parameters(args): Parameters<crate::inputs::CreateProjectInput>,
+    ) -> Result<CallToolResult, McpError> {
+        use kanban_core::operation::{CreateProject, Operation};
+        let id = uuid::Uuid::now_v7();
+        let prefix = args.prefix.clone();
+        self.blocking_mut(move |ws| {
+            ws.apply(Operation::CreateProject(CreateProject {
+                id,
+                name: args.name,
+                prefix: args.prefix,
+                description: args.description,
+                icon: None,
+            }))
+            .map(|_| ())
+        })
+        .await?;
+        json_content(&serde_json::json!({ "created": prefix }))
     }
 }
 

--- a/crates/kanban-mcp/src/server.rs
+++ b/crates/kanban-mcp/src/server.rs
@@ -107,6 +107,17 @@ impl KanbanServer {
     }
 }
 
+/// Fractional sort-key midpoint between two optional neighbours.
+/// Mirrors the GUI's 1024-gap convention.
+fn midpoint(before: Option<f64>, after: Option<f64>) -> f64 {
+    match (before, after) {
+        (Some(b), Some(a)) => f64::midpoint(b, a),
+        (Some(b), None) => b + 1024.0,
+        (None, Some(a)) => a - 1024.0,
+        (None, None) => 1024.0,
+    }
+}
+
 /// Serialize a value to a pretty-JSON text content block.
 pub(crate) fn json_content<T: serde::Serialize>(value: &T) -> Result<CallToolResult, McpError> {
     let text = serde_json::to_string_pretty(value)
@@ -491,6 +502,106 @@ impl KanbanServer {
         let map = crate::convert::status_name_map(&statuses);
         let name = map.get(&issue.status_id).cloned().unwrap_or_default();
         json_content(&crate::convert::IssueOut::from_issue(issue, &name))
+    }
+
+    #[tool(
+        description = "Move an issue: change its status column and/or reorder it before/after a sibling issue (by key). Returns the moved issue."
+    )]
+    async fn move_issue(
+        &self,
+        Parameters(args): Parameters<crate::inputs::MoveIssueInput>,
+    ) -> Result<CallToolResult, McpError> {
+        use kanban_core::operation::{IssueFieldChange, Operation, ReorderIssue, UpdateIssueField};
+        use kanban_core::query::IssueFilter;
+        use kanban_core::types::Issue;
+
+        // phase 1: resolve the dragged issue + the project's statuses + all project issues
+        let key = args.key.clone();
+        let resolved = self
+            .blocking_read(move |ws| {
+                let Some(issue) = ws.query_issue_by_identifier(&key)? else {
+                    return Ok(None);
+                };
+                let statuses = ws.query_statuses_for_project(issue.project_id)?;
+                let issues = ws.query_issues(IssueFilter::for_project(issue.project_id))?;
+                Ok(Some((issue, statuses, issues)))
+            })
+            .await?;
+        let (issue, statuses, project_issues) =
+            resolved.ok_or_else(|| crate::error::not_found("issue", &args.key))?;
+
+        // target status: named, else keep current
+        let target_status_id = match &args.status {
+            Some(name) => {
+                statuses
+                    .iter()
+                    .find(|s| &s.name == name)
+                    .ok_or_else(|| {
+                        crate::error::unknown_name(
+                            "status",
+                            name,
+                            &args.key,
+                            &statuses.iter().map(|s| s.name.clone()).collect::<Vec<_>>(),
+                        )
+                    })?
+                    .id
+            }
+            None => issue.status_id,
+        };
+
+        // target column: issues in the target status, excluding the dragged issue, by sort_key
+        let mut col: Vec<&Issue> = project_issues
+            .iter()
+            .filter(|i| i.status_id == target_status_id && i.id != issue.id)
+            .collect();
+        col.sort_by(|a, b| a.sort_key.total_cmp(&b.sort_key));
+
+        // neighbours from before/after sibling, else append to the end
+        let (before_sk, after_sk) = if let Some(bkey) = &args.before {
+            let idx = col
+                .iter()
+                .position(|i| &i.identifier == bkey)
+                .ok_or_else(|| crate::error::not_found("sibling issue", bkey))?;
+            let before = if idx > 0 {
+                Some(col[idx - 1].sort_key)
+            } else {
+                None
+            };
+            (before, Some(col[idx].sort_key))
+        } else if let Some(akey) = &args.after {
+            let idx = col
+                .iter()
+                .position(|i| &i.identifier == akey)
+                .ok_or_else(|| crate::error::not_found("sibling issue", akey))?;
+            let after = col.get(idx + 1).map(|i| i.sort_key);
+            (Some(col[idx].sort_key), after)
+        } else {
+            (col.last().map(|i| i.sort_key), None)
+        };
+        let new_sort_key = midpoint(before_sk, after_sk);
+
+        // phase 3: apply status change (if any) + reorder, re-read
+        let issue_id = issue.id;
+        let current_status = issue.status_id;
+        let moved = self
+            .blocking_mut(move |ws| {
+                if target_status_id != current_status {
+                    ws.apply(Operation::UpdateIssueField(UpdateIssueField {
+                        id: issue_id,
+                        change: IssueFieldChange::Status(target_status_id),
+                    }))?;
+                }
+                ws.apply(Operation::ReorderIssue(ReorderIssue {
+                    id: issue_id,
+                    new_sort_key,
+                }))?;
+                ws.query_issue_by_id(issue_id)
+            })
+            .await?;
+
+        let map = crate::convert::status_name_map(&statuses);
+        let name = map.get(&moved.status_id).cloned().unwrap_or_default();
+        json_content(&crate::convert::IssueOut::from_issue(moved, &name))
     }
 }
 

--- a/crates/kanban-mcp/src/server.rs
+++ b/crates/kanban-mcp/src/server.rs
@@ -515,6 +515,13 @@ impl KanbanServer {
         use kanban_core::query::IssueFilter;
         use kanban_core::types::Issue;
 
+        if args.before.is_some() && args.after.is_some() {
+            return Err(McpError::invalid_params(
+                "before and after are mutually exclusive; provide at most one",
+                None,
+            ));
+        }
+
         // phase 1: resolve the dragged issue + the project's statuses + all project issues
         let key = args.key.clone();
         let resolved = self

--- a/crates/kanban-mcp/src/server.rs
+++ b/crates/kanban-mcp/src/server.rs
@@ -1,0 +1,91 @@
+use std::sync::{Arc, Mutex};
+
+use rmcp::handler::server::router::tool::ToolRouter;
+use rmcp::model::{
+    CallToolResult, Content, Implementation, ProtocolVersion, ServerCapabilities, ServerInfo,
+};
+use rmcp::{ErrorData as McpError, ServerHandler, tool, tool_handler, tool_router};
+
+use kanban_core::Workspace;
+
+use crate::convert::ProjectOut;
+use crate::error::to_mcp;
+
+#[derive(Clone)]
+pub struct KanbanServer {
+    workspace: Arc<Mutex<Workspace>>,
+    // Read by the `#[tool_handler]`-generated `ServerHandler` impl; dead-code
+    // analysis can't see the read through the generated trait code.
+    #[allow(dead_code)]
+    tool_router: ToolRouter<KanbanServer>,
+}
+
+impl KanbanServer {
+    /// Open the default workspace (`~/.kanban/data.db` or `$KANBAN_DB`).
+    ///
+    /// # Errors
+    /// Returns an error if the workspace cannot be opened.
+    pub fn from_default() -> anyhow::Result<Self> {
+        let ws = Workspace::open_default()?;
+        Ok(Self::with_workspace(ws))
+    }
+
+    /// Build a server around an already-open workspace (used by tests).
+    #[must_use]
+    pub fn with_workspace(ws: Workspace) -> Self {
+        Self {
+            workspace: Arc::new(Mutex::new(ws)),
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    /// Run a sync closure against the workspace on a blocking thread; the mutex
+    /// guard never crosses `.await`. Core errors are mapped to MCP errors.
+    async fn blocking<T, F>(&self, f: F) -> Result<T, McpError>
+    where
+        T: Send + 'static,
+        F: FnOnce(&mut Workspace) -> Result<T, kanban_core::Error> + Send + 'static,
+    {
+        let ws = Arc::clone(&self.workspace);
+        tokio::task::spawn_blocking(move || {
+            let mut guard = ws
+                .lock()
+                .map_err(|_| kanban_core::Error::Conflict("workspace mutex poisoned".into()))?;
+            f(&mut guard)
+        })
+        .await
+        .map_err(|e| McpError::internal_error(format!("task join error: {e}"), None))?
+        .map_err(to_mcp)
+    }
+}
+
+/// Serialize a value to a pretty-JSON text content block.
+pub(crate) fn json_content<T: serde::Serialize>(value: &T) -> Result<CallToolResult, McpError> {
+    let text = serde_json::to_string_pretty(value)
+        .map_err(|e| McpError::internal_error(format!("serialize: {e}"), None))?;
+    Ok(CallToolResult::success(vec![Content::text(text)]))
+}
+
+#[tool_router]
+impl KanbanServer {
+    #[tool(description = "List all projects (prefix, name, description).")]
+    async fn list_projects(&self) -> Result<CallToolResult, McpError> {
+        let projects = self.blocking(|ws| ws.query_projects()).await?;
+        let out: Vec<ProjectOut> = projects.into_iter().map(ProjectOut::from).collect();
+        json_content(&out)
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for KanbanServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::from_build_env())
+            .with_protocol_version(ProtocolVersion::V_2024_11_05)
+            .with_instructions(
+                "Read and manage a local kanban board. Address projects by prefix (e.g. AUTH) \
+                 and issues by key (e.g. AUTH-12). Statuses and labels are referenced by name."
+                    .to_string(),
+            )
+    }
+}

--- a/crates/kanban-mcp/src/server.rs
+++ b/crates/kanban-mcp/src/server.rs
@@ -316,6 +316,94 @@ impl KanbanServer {
         .await?;
         json_content(&serde_json::json!({ "created": prefix }))
     }
+
+    #[tool(
+        description = "Create an issue in a project. status defaults to the first column, priority to medium. Returns the created issue including its assigned key."
+    )]
+    async fn create_issue(
+        &self,
+        Parameters(args): Parameters<crate::inputs::CreateIssueInput>,
+    ) -> Result<CallToolResult, McpError> {
+        use kanban_core::operation::{CreateIssue, Operation};
+        use kanban_core::types::Priority;
+
+        // phase 1: resolve project id + statuses
+        let prefix = args.project.clone();
+        let resolved = self
+            .blocking_read(move |ws| {
+                let Some(p) = ws.query_project_by_prefix(&prefix)? else {
+                    return Ok(None);
+                };
+                let statuses = ws.query_statuses_for_project(p.id)?;
+                Ok(Some((p.id, statuses)))
+            })
+            .await?;
+        let (project_id, statuses) =
+            resolved.ok_or_else(|| crate::error::not_found("project", &args.project))?;
+
+        // status: named or first column
+        let status_id = match &args.status {
+            Some(name) => {
+                statuses
+                    .iter()
+                    .find(|s| &s.name == name)
+                    .ok_or_else(|| {
+                        crate::error::unknown_name(
+                            "status",
+                            name,
+                            &args.project,
+                            &statuses.iter().map(|s| s.name.clone()).collect::<Vec<_>>(),
+                        )
+                    })?
+                    .id
+            }
+            None => statuses
+                .first()
+                .map(|s| s.id)
+                .ok_or_else(|| McpError::internal_error("project has no statuses", None))?,
+        };
+
+        let priority: Priority = match &args.priority {
+            Some(p) => p.parse().map_err(|_| {
+                McpError::invalid_params(
+                    "priority must be one of none, low, medium, high, urgent",
+                    None,
+                )
+            })?,
+            None => Priority::Medium,
+        };
+        let due_date = match &args.due_date {
+            Some(d) => Some(
+                chrono::NaiveDate::parse_from_str(d, "%Y-%m-%d")
+                    .map_err(|_| McpError::invalid_params("due_date must be YYYY-MM-DD", None))?,
+            ),
+            None => None,
+        };
+
+        // phase 2: apply + read back the created issue (so we can return its key)
+        let id = uuid::Uuid::now_v7();
+        let title = args.title.clone();
+        let description = args.description.clone();
+        let issue = self
+            .blocking_mut(move |ws| {
+                ws.apply(Operation::CreateIssue(CreateIssue {
+                    id,
+                    project_id,
+                    title,
+                    description,
+                    status_id,
+                    priority,
+                    due_date,
+                    label_ids: vec![],
+                }))?;
+                ws.query_issue_by_id(id)
+            })
+            .await?;
+
+        let map = crate::convert::status_name_map(&statuses);
+        let name = map.get(&issue.status_id).cloned().unwrap_or_default();
+        json_content(&crate::convert::IssueOut::from_issue(issue, &name))
+    }
 }
 
 #[tool_handler]

--- a/crates/kanban-mcp/src/server.rs
+++ b/crates/kanban-mcp/src/server.rs
@@ -505,6 +505,20 @@ impl KanbanServer {
     }
 
     #[tool(
+        description = "Undo the most recent change. Note: a multi-field issue update or a move applies as more than one change, so it may take multiple undos to fully revert."
+    )]
+    async fn undo(&self) -> Result<CallToolResult, McpError> {
+        self.blocking_mut(|ws| ws.undo().map(|_| ())).await?;
+        json_content(&serde_json::json!({ "undone": true }))
+    }
+
+    #[tool(description = "Redo the most recently undone change.")]
+    async fn redo(&self) -> Result<CallToolResult, McpError> {
+        self.blocking_mut(|ws| ws.redo().map(|_| ())).await?;
+        json_content(&serde_json::json!({ "redone": true }))
+    }
+
+    #[tool(
         description = "Move an issue: change its status column and/or reorder it before/after a sibling issue (by key). Returns the moved issue."
     )]
     async fn move_issue(

--- a/crates/kanban-mcp/src/server.rs
+++ b/crates/kanban-mcp/src/server.rs
@@ -39,19 +39,19 @@ impl KanbanServer {
         }
     }
 
-    /// Run a sync closure against the workspace on a blocking thread; the mutex
-    /// guard never crosses `.await`. Core errors are mapped to MCP errors.
-    async fn blocking<T, F>(&self, f: F) -> Result<T, McpError>
+    /// Run a read-only sync closure against the workspace on a blocking thread.
+    /// The mutex guard never crosses `.await`. Core errors map to MCP errors.
+    async fn blocking_read<T, F>(&self, f: F) -> Result<T, McpError>
     where
         T: Send + 'static,
-        F: FnOnce(&mut Workspace) -> Result<T, kanban_core::Error> + Send + 'static,
+        F: FnOnce(&Workspace) -> Result<T, kanban_core::Error> + Send + 'static,
     {
         let ws = Arc::clone(&self.workspace);
         tokio::task::spawn_blocking(move || {
-            let mut guard = ws
+            let guard = ws
                 .lock()
                 .map_err(|_| kanban_core::Error::Conflict("workspace mutex poisoned".into()))?;
-            f(&mut guard)
+            f(&guard)
         })
         .await
         .map_err(|e| McpError::internal_error(format!("task join error: {e}"), None))?
@@ -70,7 +70,7 @@ pub(crate) fn json_content<T: serde::Serialize>(value: &T) -> Result<CallToolRes
 impl KanbanServer {
     #[tool(description = "List all projects (prefix, name, description).")]
     async fn list_projects(&self) -> Result<CallToolResult, McpError> {
-        let projects = self.blocking(|ws| ws.query_projects()).await?;
+        let projects = self.blocking_read(Workspace::query_projects).await?;
         let out: Vec<ProjectOut> = projects.into_iter().map(ProjectOut::from).collect();
         json_content(&out)
     }

--- a/crates/kanban-mcp/src/server.rs
+++ b/crates/kanban-mcp/src/server.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use rmcp::handler::server::router::tool::ToolRouter;
+use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{
     CallToolResult, Content, Implementation, ProtocolVersion, ServerCapabilities, ServerInfo,
 };
@@ -72,6 +73,52 @@ impl KanbanServer {
     async fn list_projects(&self) -> Result<CallToolResult, McpError> {
         let projects = self.blocking_read(Workspace::query_projects).await?;
         let out: Vec<ProjectOut> = projects.into_iter().map(ProjectOut::from).collect();
+        json_content(&out)
+    }
+
+    #[tool(
+        description = "List the status columns of a project, in board order. `project` is the prefix, e.g. AUTH."
+    )]
+    async fn list_statuses(
+        &self,
+        Parameters(args): Parameters<crate::inputs::ProjectRef>,
+    ) -> Result<CallToolResult, McpError> {
+        let prefix = args.project.clone();
+        let statuses = self
+            .blocking_read(move |ws| {
+                let Some(p) = ws.query_project_by_prefix(&prefix)? else {
+                    return Ok(None);
+                };
+                Ok(Some(ws.query_statuses_for_project(p.id)?))
+            })
+            .await?;
+        let statuses = statuses.ok_or_else(|| crate::error::not_found("project", &args.project))?;
+        let out: Vec<crate::convert::StatusOut> = statuses
+            .into_iter()
+            .map(crate::convert::StatusOut::from)
+            .collect();
+        json_content(&out)
+    }
+
+    #[tool(description = "List the labels of a project. `project` is the prefix, e.g. AUTH.")]
+    async fn list_labels(
+        &self,
+        Parameters(args): Parameters<crate::inputs::ProjectRef>,
+    ) -> Result<CallToolResult, McpError> {
+        let prefix = args.project.clone();
+        let labels = self
+            .blocking_read(move |ws| {
+                let Some(p) = ws.query_project_by_prefix(&prefix)? else {
+                    return Ok(None);
+                };
+                Ok(Some(ws.query_labels_for_project(p.id)?))
+            })
+            .await?;
+        let labels = labels.ok_or_else(|| crate::error::not_found("project", &args.project))?;
+        let out: Vec<crate::convert::LabelOut> = labels
+            .into_iter()
+            .map(crate::convert::LabelOut::from)
+            .collect();
         json_content(&out)
     }
 }

--- a/crates/kanban-mcp/src/server.rs
+++ b/crates/kanban-mcp/src/server.rs
@@ -58,6 +58,34 @@ impl KanbanServer {
         .map_err(|e| McpError::internal_error(format!("task join error: {e}"), None))?
         .map_err(to_mcp)
     }
+
+    /// Resolve a project's statuses + run a project-scoped read in one lock.
+    /// `f(ws, project_id, &statuses)` yields the read result. An unknown prefix
+    /// maps to a not-found error.
+    async fn with_project<T, F>(&self, prefix: &str, f: F) -> Result<T, McpError>
+    where
+        T: Send + 'static,
+        F: FnOnce(
+                &Workspace,
+                uuid::Uuid,
+                &[kanban_core::types::Status],
+            ) -> Result<T, kanban_core::Error>
+            + Send
+            + 'static,
+    {
+        let owned = prefix.to_string();
+        let for_err = prefix.to_string();
+        let out = self
+            .blocking_read(move |ws| {
+                let Some(p) = ws.query_project_by_prefix(&owned)? else {
+                    return Ok(None);
+                };
+                let statuses = ws.query_statuses_for_project(p.id)?;
+                f(ws, p.id, &statuses).map(Some)
+            })
+            .await?;
+        out.ok_or_else(|| crate::error::not_found("project", &for_err))
+    }
 }
 
 /// Serialize a value to a pretty-JSON text content block.
@@ -83,16 +111,9 @@ impl KanbanServer {
         &self,
         Parameters(args): Parameters<crate::inputs::ProjectRef>,
     ) -> Result<CallToolResult, McpError> {
-        let prefix = args.project.clone();
         let statuses = self
-            .blocking_read(move |ws| {
-                let Some(p) = ws.query_project_by_prefix(&prefix)? else {
-                    return Ok(None);
-                };
-                Ok(Some(ws.query_statuses_for_project(p.id)?))
-            })
+            .with_project(&args.project, |_ws, _id, statuses| Ok(statuses.to_vec()))
             .await?;
-        let statuses = statuses.ok_or_else(|| crate::error::not_found("project", &args.project))?;
         let out: Vec<crate::convert::StatusOut> = statuses
             .into_iter()
             .map(crate::convert::StatusOut::from)
@@ -105,19 +126,152 @@ impl KanbanServer {
         &self,
         Parameters(args): Parameters<crate::inputs::ProjectRef>,
     ) -> Result<CallToolResult, McpError> {
+        let labels: Vec<kanban_core::types::Label> = self
+            .with_project(&args.project, |ws, id, _statuses| {
+                ws.query_labels_for_project(id)
+            })
+            .await?;
+        let out: Vec<crate::convert::LabelOut> = labels
+            .into_iter()
+            .map(crate::convert::LabelOut::from)
+            .collect();
+        json_content(&out)
+    }
+
+    #[tool(
+        description = "List issues in a project. Optionally filter by status name, priority, or a search term."
+    )]
+    async fn list_issues(
+        &self,
+        Parameters(args): Parameters<crate::inputs::ListIssues>,
+    ) -> Result<CallToolResult, McpError> {
+        use kanban_core::query::IssueFilter;
+        use kanban_core::types::Priority;
+
+        // phase 1: resolve project id + its statuses
         let prefix = args.project.clone();
-        let labels = self
+        let resolved = self
             .blocking_read(move |ws| {
                 let Some(p) = ws.query_project_by_prefix(&prefix)? else {
                     return Ok(None);
                 };
-                Ok(Some(ws.query_labels_for_project(p.id)?))
+                let statuses = ws.query_statuses_for_project(p.id)?;
+                Ok(Some((p.id, statuses)))
             })
             .await?;
-        let labels = labels.ok_or_else(|| crate::error::not_found("project", &args.project))?;
-        let out: Vec<crate::convert::LabelOut> = labels
+        let (project_id, statuses) =
+            resolved.ok_or_else(|| crate::error::not_found("project", &args.project))?;
+
+        // phase 2: build filter (name/priority resolution -> McpError here)
+        let mut filter = IssueFilter::for_project(project_id);
+        if let Some(name) = &args.status {
+            let s = statuses.iter().find(|s| &s.name == name).ok_or_else(|| {
+                crate::error::unknown_name(
+                    "status",
+                    name,
+                    &args.project,
+                    &statuses.iter().map(|s| s.name.clone()).collect::<Vec<_>>(),
+                )
+            })?;
+            filter.status_ids = vec![s.id];
+        }
+        if let Some(pr) = &args.priority {
+            let parsed: Priority = pr.parse().map_err(|_| {
+                McpError::invalid_params(
+                    "priority must be one of none, low, medium, high, urgent",
+                    None,
+                )
+            })?;
+            filter.priorities = vec![parsed];
+        }
+        filter.search_text = args.search.clone();
+
+        // phase 3: query
+        let issues = self
+            .blocking_read(move |ws| ws.query_issues(filter))
+            .await?;
+        let map = crate::convert::status_name_map(&statuses);
+        let out: Vec<crate::convert::IssueOut> = issues
             .into_iter()
-            .map(crate::convert::LabelOut::from)
+            .map(|i| {
+                let name = map.get(&i.status_id).cloned().unwrap_or_default();
+                crate::convert::IssueOut::from_issue(i, &name)
+            })
+            .collect();
+        json_content(&out)
+    }
+
+    #[tool(
+        description = "Get one issue by key (e.g. AUTH-12), including its markdown description."
+    )]
+    async fn get_issue(
+        &self,
+        Parameters(args): Parameters<crate::inputs::IssueKey>,
+    ) -> Result<CallToolResult, McpError> {
+        let key = args.key.clone();
+        let resolved = self
+            .blocking_read(move |ws| {
+                let Some(issue) = ws.query_issue_by_identifier(&key)? else {
+                    return Ok(None);
+                };
+                let statuses = ws.query_statuses_for_project(issue.project_id)?;
+                Ok(Some((issue, statuses)))
+            })
+            .await?;
+        let (issue, statuses) =
+            resolved.ok_or_else(|| crate::error::not_found("issue", &args.key))?;
+        let name = statuses
+            .iter()
+            .find(|s| s.id == issue.status_id)
+            .map(|s| s.name.clone())
+            .unwrap_or_default();
+        json_content(&crate::convert::IssueOut::from_issue(issue, &name))
+    }
+
+    #[tool(
+        description = "Full-text search issues by title/description. Optionally scope to a project prefix."
+    )]
+    async fn search_issues(
+        &self,
+        Parameters(args): Parameters<crate::inputs::SearchIssues>,
+    ) -> Result<CallToolResult, McpError> {
+        use kanban_core::query::IssueFilter;
+
+        let project = args.project.clone();
+        let query = args.query.clone();
+        let resolved = self
+            .blocking_read(move |ws| {
+                let pid = match &project {
+                    Some(prefix) => match ws.query_project_by_prefix(prefix)? {
+                        Some(p) => Some(p.id),
+                        None => return Ok(None), // unknown project
+                    },
+                    None => None,
+                };
+                // collect all statuses so we can name statuses across projects
+                let projects = ws.query_projects()?;
+                let mut statuses = Vec::new();
+                for p in &projects {
+                    statuses.extend(ws.query_statuses_for_project(p.id)?);
+                }
+                let filter = match pid {
+                    Some(id) => IssueFilter::for_project(id),
+                    None => IssueFilter::default(),
+                };
+                let issues = ws.search(&query, filter)?;
+                Ok(Some((issues, statuses)))
+            })
+            .await?;
+        let (issues, statuses) = resolved.ok_or_else(|| {
+            crate::error::not_found("project", args.project.as_deref().unwrap_or(""))
+        })?;
+        let map = crate::convert::status_name_map(&statuses);
+        let out: Vec<crate::convert::IssueOut> = issues
+            .into_iter()
+            .map(|i| {
+                let name = map.get(&i.status_id).cloned().unwrap_or_default();
+                crate::convert::IssueOut::from_issue(i, &name)
+            })
             .collect();
         json_content(&out)
     }

--- a/crates/kanban-mcp/tests/e2e_flow.rs
+++ b/crates/kanban-mcp/tests/e2e_flow.rs
@@ -1,0 +1,103 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+//! End-to-end acceptance: a full create → move → update → undo/redo loop driven
+//! over the in-process stdio transport. The executable form of the design's
+//! acceptance criteria 2-3.
+use kanban_core::Workspace;
+use kanban_mcp::server::KanbanServer;
+use rmcp::model::CallToolRequestParams;
+use rmcp::{ClientHandler, ServiceExt};
+
+#[derive(Default, Clone)]
+struct TestClient;
+impl ClientHandler for TestClient {}
+
+/// Call a tool with JSON args and return the parsed JSON content block.
+async fn call(
+    client: &rmcp::service::RunningService<rmcp::RoleClient, TestClient>,
+    name: &str,
+    args: serde_json::Map<String, serde_json::Value>,
+) -> serde_json::Value {
+    let result = client
+        .call_tool(CallToolRequestParams::new(name.to_string()).with_arguments(args))
+        .await
+        .unwrap();
+    let text = result.content[0]
+        .as_text()
+        .expect("first content block is text");
+    serde_json::from_str(&text.text).unwrap()
+}
+
+#[tokio::test]
+async fn e2e_create_move_update_undo_flow() {
+    let dir = tempfile::tempdir().unwrap();
+    let ws = Workspace::open(&dir.path().join("data.db")).unwrap();
+    let server = KanbanServer::with_workspace(ws);
+    let (server_t, client_t) = tokio::io::duplex(8192);
+
+    let server_handle = tokio::spawn(async move {
+        let svc = server.serve(server_t).await?;
+        svc.waiting().await?;
+        anyhow::Ok(())
+    });
+
+    let client = TestClient.serve(client_t).await.unwrap();
+
+    // create a project and an issue
+    call(
+        &client,
+        "create_project",
+        rmcp::object!({"name": "Auth", "prefix": "AUTH"}),
+    )
+    .await;
+    let issue = call(
+        &client,
+        "create_issue",
+        rmcp::object!({"project": "AUTH", "title": "Original"}),
+    )
+    .await;
+    assert_eq!(issue["key"], "AUTH-1", "got: {issue}");
+    assert_eq!(issue["status"], "Todo", "got: {issue}");
+
+    // move it to another column
+    call(
+        &client,
+        "move_issue",
+        rmcp::object!({"key": "AUTH-1", "status": "In Progress"}),
+    )
+    .await;
+    let issue = call(&client, "get_issue", rmcp::object!({"key": "AUTH-1"})).await;
+    assert_eq!(issue["status"], "In Progress", "got: {issue}");
+
+    // update the title (a single operation)
+    call(
+        &client,
+        "update_issue",
+        rmcp::object!({"key": "AUTH-1", "title": "Renamed"}),
+    )
+    .await;
+    let issue = call(&client, "get_issue", rmcp::object!({"key": "AUTH-1"})).await;
+    assert_eq!(issue["title"], "Renamed", "got: {issue}");
+
+    // undo reverts the most recent change (the title), not the earlier move
+    call(&client, "undo", rmcp::object!({})).await;
+    let issue = call(&client, "get_issue", rmcp::object!({"key": "AUTH-1"})).await;
+    assert_eq!(
+        issue["title"], "Original",
+        "undo should revert the title: {issue}"
+    );
+    assert_eq!(
+        issue["status"], "In Progress",
+        "undo reverts only the last change: {issue}"
+    );
+
+    // redo re-applies the title change
+    call(&client, "redo", rmcp::object!({})).await;
+    let issue = call(&client, "get_issue", rmcp::object!({"key": "AUTH-1"})).await;
+    assert_eq!(issue["title"], "Renamed", "got: {issue}");
+
+    client.cancel().await.unwrap();
+    server_handle
+        .await
+        .expect("server task panicked")
+        .expect("server task errored");
+}

--- a/crates/kanban-mcp/tests/stdio_smoke.rs
+++ b/crates/kanban-mcp/tests/stdio_smoke.rs
@@ -10,6 +10,28 @@ use uuid::Uuid;
 struct TestClient;
 impl ClientHandler for TestClient {}
 
+/// Call `list_issues` with the given arguments and return the issue keys in
+/// the order the server returns them (`sort_key` order for the default filter).
+async fn list_keys(
+    client: &rmcp::service::RunningService<rmcp::RoleClient, TestClient>,
+    args: serde_json::Map<String, serde_json::Value>,
+) -> Vec<String> {
+    let result = client
+        .call_tool(CallToolRequestParams::new("list_issues").with_arguments(args))
+        .await
+        .unwrap();
+    let text = result.content[0]
+        .as_text()
+        .expect("first content block is text");
+    let parsed: serde_json::Value = serde_json::from_str(&text.text).unwrap();
+    parsed
+        .as_array()
+        .expect("issues is an array")
+        .iter()
+        .map(|i| i["key"].as_str().unwrap().to_owned())
+        .collect()
+}
+
 #[tokio::test]
 async fn lists_tools_and_calls_list_projects() {
     let dir = tempfile::tempdir().unwrap();
@@ -457,6 +479,134 @@ async fn update_issue_tool() {
     assert!(
         err.is_err(),
         "expected error for unknown status, got: {err:?}"
+    );
+
+    client.cancel().await.unwrap();
+    server_handle
+        .await
+        .expect("server task panicked")
+        .expect("server task errored");
+}
+
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn move_issue_tool() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut ws = Workspace::open(&dir.path().join("data.db")).unwrap();
+    let project_id = Uuid::now_v7();
+    ws.apply(Operation::CreateProject(CreateProject {
+        id: project_id,
+        name: "Auth".into(),
+        prefix: "AUTH".into(),
+        description: None,
+        icon: None,
+    }))
+    .unwrap();
+
+    let statuses = ws.query_statuses_for_project(project_id).unwrap();
+    let todo = statuses
+        .iter()
+        .find(|s| s.name == "Todo")
+        .expect("a 'Todo' default status");
+
+    // Three issues in "Todo", created in order so their sort_keys ascend.
+    for title in ["First", "Second", "Third"] {
+        ws.apply(Operation::CreateIssue(CreateIssue {
+            id: Uuid::now_v7(),
+            project_id,
+            title: title.into(),
+            description: None,
+            status_id: todo.id,
+            priority: Priority::Medium,
+            due_date: None,
+            label_ids: vec![],
+        }))
+        .unwrap();
+    }
+
+    let server = KanbanServer::with_workspace(ws);
+    let (server_t, client_t) = tokio::io::duplex(8192);
+
+    let server_handle = tokio::spawn(async move {
+        let svc = server.serve(server_t).await?;
+        svc.waiting().await?;
+        anyhow::Ok(())
+    });
+
+    let client = TestClient.serve(client_t).await.unwrap();
+
+    let tools = client.list_all_tools().await.unwrap();
+    assert!(tools.iter().any(|t| t.name == "move_issue"));
+
+    // Initial order is AUTH-1, AUTH-2, AUTH-3.
+    assert_eq!(
+        list_keys(&client, rmcp::object!({"project": "AUTH"})).await,
+        vec!["AUTH-1", "AUTH-2", "AUTH-3"],
+    );
+
+    // Move AUTH-3 before AUTH-1 -> order becomes AUTH-3, AUTH-1, AUTH-2.
+    client
+        .call_tool(
+            CallToolRequestParams::new("move_issue")
+                .with_arguments(rmcp::object!({"key": "AUTH-3", "before": "AUTH-1"})),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        list_keys(&client, rmcp::object!({"project": "AUTH"})).await,
+        vec!["AUTH-3", "AUTH-1", "AUTH-2"],
+    );
+
+    // Move AUTH-1 to "In Progress" (no sibling) -> returned status is "In Progress".
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("move_issue")
+                .with_arguments(rmcp::object!({"key": "AUTH-1", "status": "In Progress"})),
+        )
+        .await
+        .unwrap();
+    let text = result.content[0]
+        .as_text()
+        .expect("first content block is text");
+    let parsed: serde_json::Value = serde_json::from_str(&text.text).unwrap();
+    assert_eq!(parsed["key"], "AUTH-1", "got: {parsed}");
+    assert_eq!(parsed["status"], "In Progress", "got: {parsed}");
+
+    // list_issues scoped to "In Progress" contains AUTH-1.
+    let in_progress = list_keys(
+        &client,
+        rmcp::object!({"project": "AUTH", "status": "In Progress"}),
+    )
+    .await;
+    assert_eq!(in_progress, vec!["AUTH-1"], "got: {in_progress:?}");
+
+    // AUTH-1 left the Todo column.
+    let todo_keys = list_keys(
+        &client,
+        rmcp::object!({"project": "AUTH", "status": "Todo"}),
+    )
+    .await;
+    assert_eq!(todo_keys, vec!["AUTH-3", "AUTH-2"], "got: {todo_keys:?}");
+
+    // Unknown issue key -> error.
+    let err = client
+        .call_tool(
+            CallToolRequestParams::new("move_issue")
+                .with_arguments(rmcp::object!({"key": "AUTH-999", "before": "AUTH-1"})),
+        )
+        .await;
+    assert!(err.is_err(), "expected error for unknown key, got: {err:?}");
+
+    // Unknown sibling key -> error.
+    let err = client
+        .call_tool(
+            CallToolRequestParams::new("move_issue")
+                .with_arguments(rmcp::object!({"key": "AUTH-2", "before": "AUTH-999"})),
+        )
+        .await;
+    assert!(
+        err.is_err(),
+        "expected error for unknown sibling, got: {err:?}"
     );
 
     client.cancel().await.unwrap();

--- a/crates/kanban-mcp/tests/stdio_smoke.rs
+++ b/crates/kanban-mcp/tests/stdio_smoke.rs
@@ -1,0 +1,48 @@
+#![allow(clippy::unwrap_used)]
+use kanban_core::Workspace;
+use kanban_core::operation::{CreateProject, Operation};
+use kanban_mcp::server::KanbanServer;
+use rmcp::{ClientHandler, ServiceExt, model::CallToolRequestParams};
+use uuid::Uuid;
+
+#[derive(Default, Clone)]
+struct TestClient;
+impl ClientHandler for TestClient {}
+
+#[tokio::test]
+async fn lists_tools_and_calls_list_projects() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut ws = Workspace::open(&dir.path().join("data.db")).unwrap();
+    ws.apply(Operation::CreateProject(CreateProject {
+        id: Uuid::now_v7(),
+        name: "Auth".into(),
+        prefix: "AUTH".into(),
+        description: None,
+        icon: None,
+    }))
+    .unwrap();
+
+    let server = KanbanServer::with_workspace(ws);
+    let (server_t, client_t) = tokio::io::duplex(8192);
+
+    let server_handle = tokio::spawn(async move {
+        let svc = server.serve(server_t).await?;
+        svc.waiting().await?;
+        anyhow::Ok(())
+    });
+
+    let client = TestClient.serve(client_t).await.unwrap();
+
+    let tools = client.list_all_tools().await.unwrap();
+    assert!(tools.iter().any(|t| t.name == "list_projects"));
+
+    let result = client
+        .call_tool(CallToolRequestParams::new("list_projects"))
+        .await
+        .unwrap();
+    let text = format!("{:?}", result.content);
+    assert!(text.contains("AUTH"), "got: {text}");
+
+    client.cancel().await.unwrap();
+    let _ = server_handle.await;
+}

--- a/crates/kanban-mcp/tests/stdio_smoke.rs
+++ b/crates/kanban-mcp/tests/stdio_smoke.rs
@@ -249,6 +249,95 @@ async fn create_project_tool() {
 }
 
 #[tokio::test]
+async fn create_issue_tool() {
+    // Empty workspace, then create a project so we can add issues to it.
+    let dir = tempfile::tempdir().unwrap();
+    let ws = Workspace::open(&dir.path().join("data.db")).unwrap();
+
+    let server = KanbanServer::with_workspace(ws);
+    let (server_t, client_t) = tokio::io::duplex(8192);
+
+    let server_handle = tokio::spawn(async move {
+        let svc = server.serve(server_t).await?;
+        svc.waiting().await?;
+        anyhow::Ok(())
+    });
+
+    let client = TestClient.serve(client_t).await.unwrap();
+
+    let tools = client.list_all_tools().await.unwrap();
+    assert!(tools.iter().any(|t| t.name == "create_issue"));
+
+    client
+        .call_tool(
+            CallToolRequestParams::new("create_project")
+                .with_arguments(rmcp::object!({"name": "Auth Service", "prefix": "AUTH"})),
+        )
+        .await
+        .unwrap();
+
+    // Create an issue with defaults: returns the full IssueOut with the
+    // core-assigned key ("AUTH-1"), default first status ("Todo"), default
+    // priority ("medium").
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("create_issue")
+                .with_arguments(rmcp::object!({"project": "AUTH", "title": "Add login"})),
+        )
+        .await
+        .unwrap();
+    let text = result.content[0]
+        .as_text()
+        .expect("first content block is text");
+    let parsed: serde_json::Value = serde_json::from_str(&text.text).unwrap();
+    assert_eq!(parsed["key"], "AUTH-1", "got: {parsed}");
+    assert_eq!(parsed["title"], "Add login", "got: {parsed}");
+    assert_eq!(parsed["status"], "Todo", "got: {parsed}");
+    assert_eq!(parsed["priority"], "medium", "got: {parsed}");
+
+    // Bad priority is rejected.
+    let err =
+        client
+            .call_tool(CallToolRequestParams::new("create_issue").with_arguments(
+                rmcp::object!({"project": "AUTH", "title": "x", "priority": "bogus"}),
+            ))
+            .await;
+    assert!(
+        err.is_err(),
+        "expected error for bad priority, got: {err:?}"
+    );
+
+    // Unknown status name is rejected.
+    let err = client
+        .call_tool(CallToolRequestParams::new("create_issue").with_arguments(
+            rmcp::object!({"project": "AUTH", "title": "x", "status": "NoSuchStatus"}),
+        ))
+        .await;
+    assert!(
+        err.is_err(),
+        "expected error for unknown status, got: {err:?}"
+    );
+
+    // Unknown project is rejected.
+    let err = client
+        .call_tool(
+            CallToolRequestParams::new("create_issue")
+                .with_arguments(rmcp::object!({"project": "NOPE", "title": "x"})),
+        )
+        .await;
+    assert!(
+        err.is_err(),
+        "expected error for unknown project, got: {err:?}"
+    );
+
+    client.cancel().await.unwrap();
+    server_handle
+        .await
+        .expect("server task panicked")
+        .expect("server task errored");
+}
+
+#[tokio::test]
 async fn list_statuses_and_labels() {
     let dir = tempfile::tempdir().unwrap();
     let mut ws = Workspace::open(&dir.path().join("data.db")).unwrap();

--- a/crates/kanban-mcp/tests/stdio_smoke.rs
+++ b/crates/kanban-mcp/tests/stdio_smoke.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::unwrap_used)]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 use kanban_core::Workspace;
 use kanban_core::operation::{CreateProject, Operation};
 use kanban_mcp::server::KanbanServer;
@@ -40,9 +40,17 @@ async fn lists_tools_and_calls_list_projects() {
         .call_tool(CallToolRequestParams::new("list_projects"))
         .await
         .unwrap();
-    let text = format!("{:?}", result.content);
-    assert!(text.contains("AUTH"), "got: {text}");
+    // The tool returns a JSON text block; parse it and assert on the structure
+    // so a field-name / nesting regression would fail the test.
+    let text = result.content[0]
+        .as_text()
+        .expect("first content block is text");
+    let parsed: serde_json::Value = serde_json::from_str(&text.text).unwrap();
+    assert_eq!(parsed[0]["prefix"], "AUTH", "got: {parsed}");
 
     client.cancel().await.unwrap();
-    let _ = server_handle.await;
+    server_handle
+        .await
+        .expect("server task panicked")
+        .expect("server task errored");
 }

--- a/crates/kanban-mcp/tests/stdio_smoke.rs
+++ b/crates/kanban-mcp/tests/stdio_smoke.rs
@@ -647,6 +647,123 @@ async fn move_issue_tool() {
 }
 
 #[tokio::test]
+async fn undo_redo_tools() {
+    // Empty workspace — every action happens through the MCP tools.
+    let dir = tempfile::tempdir().unwrap();
+    let ws = Workspace::open(&dir.path().join("data.db")).unwrap();
+
+    let server = KanbanServer::with_workspace(ws);
+    let (server_t, client_t) = tokio::io::duplex(8192);
+
+    let server_handle = tokio::spawn(async move {
+        let svc = server.serve(server_t).await?;
+        svc.waiting().await?;
+        anyhow::Ok(())
+    });
+
+    let client = TestClient.serve(client_t).await.unwrap();
+
+    // Both tools appear in the tool list.
+    let tools = client.list_all_tools().await.unwrap();
+    assert!(
+        tools.iter().any(|t| t.name == "undo"),
+        "undo missing from tools"
+    );
+    assert!(
+        tools.iter().any(|t| t.name == "redo"),
+        "redo missing from tools"
+    );
+
+    // Create a project via MCP.
+    client
+        .call_tool(
+            CallToolRequestParams::new("create_project")
+                .with_arguments(rmcp::object!({"name": "Auth Service", "prefix": "AUTH"})),
+        )
+        .await
+        .unwrap();
+
+    // Confirm it exists.
+    let result = client
+        .call_tool(CallToolRequestParams::new("list_projects"))
+        .await
+        .unwrap();
+    let text = result.content[0].as_text().expect("text content");
+    let parsed: serde_json::Value = serde_json::from_str(&text.text).unwrap();
+    let projects = parsed.as_array().expect("projects array");
+    assert!(
+        projects.iter().any(|p| p["prefix"] == "AUTH"),
+        "expected AUTH before undo, got: {parsed}"
+    );
+
+    // Undo the create -> list_projects returns empty.
+    let result = client
+        .call_tool(CallToolRequestParams::new("undo"))
+        .await
+        .unwrap();
+    let text = result.content[0].as_text().expect("text content");
+    let parsed: serde_json::Value = serde_json::from_str(&text.text).unwrap();
+    assert_eq!(
+        parsed["undone"], true,
+        "expected undone:true, got: {parsed}"
+    );
+
+    let result = client
+        .call_tool(CallToolRequestParams::new("list_projects"))
+        .await
+        .unwrap();
+    let text = result.content[0].as_text().expect("text content");
+    let parsed: serde_json::Value = serde_json::from_str(&text.text).unwrap();
+    let projects = parsed.as_array().expect("projects array");
+    assert!(
+        projects.is_empty(),
+        "expected empty list after undo, got: {parsed}"
+    );
+
+    // Redo -> AUTH is back.
+    let result = client
+        .call_tool(CallToolRequestParams::new("redo"))
+        .await
+        .unwrap();
+    let text = result.content[0].as_text().expect("text content");
+    let parsed: serde_json::Value = serde_json::from_str(&text.text).unwrap();
+    assert_eq!(
+        parsed["redone"], true,
+        "expected redone:true, got: {parsed}"
+    );
+
+    let result = client
+        .call_tool(CallToolRequestParams::new("list_projects"))
+        .await
+        .unwrap();
+    let text = result.content[0].as_text().expect("text content");
+    let parsed: serde_json::Value = serde_json::from_str(&text.text).unwrap();
+    let projects = parsed.as_array().expect("projects array");
+    assert!(
+        projects.iter().any(|p| p["prefix"] == "AUTH"),
+        "expected AUTH after redo, got: {parsed}"
+    );
+
+    // Undo once more (back to empty) then undo again -> error (nothing to undo).
+    client
+        .call_tool(CallToolRequestParams::new("undo"))
+        .await
+        .unwrap();
+
+    let err = client.call_tool(CallToolRequestParams::new("undo")).await;
+    assert!(
+        err.is_err(),
+        "expected error when nothing left to undo, got: {err:?}"
+    );
+
+    client.cancel().await.unwrap();
+    server_handle
+        .await
+        .expect("server task panicked")
+        .expect("server task errored");
+}
+
+#[tokio::test]
 async fn list_statuses_and_labels() {
     let dir = tempfile::tempdir().unwrap();
     let mut ws = Workspace::open(&dir.path().join("data.db")).unwrap();

--- a/crates/kanban-mcp/tests/stdio_smoke.rs
+++ b/crates/kanban-mcp/tests/stdio_smoke.rs
@@ -609,6 +609,36 @@ async fn move_issue_tool() {
         "expected error for unknown sibling, got: {err:?}"
     );
 
+    // `after` reorder: move AUTH-3 to land after AUTH-2 in Todo -> [AUTH-2, AUTH-3].
+    client
+        .call_tool(
+            CallToolRequestParams::new("move_issue")
+                .with_arguments(rmcp::object!({"key": "AUTH-3", "after": "AUTH-2"})),
+        )
+        .await
+        .unwrap();
+    let todo_keys = list_keys(
+        &client,
+        rmcp::object!({"project": "AUTH", "status": "Todo"}),
+    )
+    .await;
+    assert_eq!(
+        todo_keys,
+        vec!["AUTH-2", "AUTH-3"],
+        "after-reorder, got: {todo_keys:?}"
+    );
+
+    // `before` and `after` are mutually exclusive.
+    let err = client
+        .call_tool(CallToolRequestParams::new("move_issue").with_arguments(
+            rmcp::object!({"key": "AUTH-2", "before": "AUTH-3", "after": "AUTH-3"}),
+        ))
+        .await;
+    assert!(
+        err.is_err(),
+        "expected error for before+after, got: {err:?}"
+    );
+
     client.cancel().await.unwrap();
     server_handle
         .await

--- a/crates/kanban-mcp/tests/stdio_smoke.rs
+++ b/crates/kanban-mcp/tests/stdio_smoke.rs
@@ -338,6 +338,135 @@ async fn create_issue_tool() {
 }
 
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn update_issue_tool() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut ws = Workspace::open(&dir.path().join("data.db")).unwrap();
+    let project_id = Uuid::now_v7();
+    ws.apply(Operation::CreateProject(CreateProject {
+        id: project_id,
+        name: "Auth".into(),
+        prefix: "AUTH".into(),
+        description: None,
+        icon: None,
+    }))
+    .unwrap();
+
+    let statuses = ws.query_statuses_for_project(project_id).unwrap();
+    let todo = statuses
+        .iter()
+        .find(|s| s.name == "Todo")
+        .expect("a 'Todo' default status");
+
+    ws.apply(Operation::CreateIssue(CreateIssue {
+        id: Uuid::now_v7(),
+        project_id,
+        title: "Old".into(),
+        description: None,
+        status_id: todo.id,
+        priority: Priority::Medium,
+        due_date: None,
+        label_ids: vec![],
+    }))
+    .unwrap();
+
+    let server = KanbanServer::with_workspace(ws);
+    let (server_t, client_t) = tokio::io::duplex(8192);
+
+    let server_handle = tokio::spawn(async move {
+        let svc = server.serve(server_t).await?;
+        svc.waiting().await?;
+        anyhow::Ok(())
+    });
+
+    let client = TestClient.serve(client_t).await.unwrap();
+
+    let tools = client.list_all_tools().await.unwrap();
+    assert!(tools.iter().any(|t| t.name == "update_issue"));
+
+    // Update title + priority; status stays "Todo".
+    let result =
+        client
+            .call_tool(CallToolRequestParams::new("update_issue").with_arguments(
+                rmcp::object!({"key": "AUTH-1", "title": "New", "priority": "high"}),
+            ))
+            .await
+            .unwrap();
+    let text = result.content[0]
+        .as_text()
+        .expect("first content block is text");
+    let parsed: serde_json::Value = serde_json::from_str(&text.text).unwrap();
+    assert_eq!(parsed["title"], "New", "got: {parsed}");
+    assert_eq!(parsed["priority"], "high", "got: {parsed}");
+    assert_eq!(parsed["status"], "Todo", "got: {parsed}");
+
+    // Update status only.
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("update_issue")
+                .with_arguments(rmcp::object!({"key": "AUTH-1", "status": "In Progress"})),
+        )
+        .await
+        .unwrap();
+    let text = result.content[0]
+        .as_text()
+        .expect("first content block is text");
+    let parsed: serde_json::Value = serde_json::from_str(&text.text).unwrap();
+    assert_eq!(parsed["status"], "In Progress", "got: {parsed}");
+
+    // get_issue reflects both updates.
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("get_issue")
+                .with_arguments(rmcp::object!({"key": "AUTH-1"})),
+        )
+        .await
+        .unwrap();
+    let text = result.content[0]
+        .as_text()
+        .expect("first content block is text");
+    let parsed: serde_json::Value = serde_json::from_str(&text.text).unwrap();
+    assert_eq!(parsed["title"], "New", "got: {parsed}");
+    assert_eq!(parsed["status"], "In Progress", "got: {parsed}");
+
+    // No fields -> invalid_params error.
+    let err = client
+        .call_tool(
+            CallToolRequestParams::new("update_issue")
+                .with_arguments(rmcp::object!({"key": "AUTH-1"})),
+        )
+        .await;
+    assert!(err.is_err(), "expected error for no fields, got: {err:?}");
+
+    // Unknown issue key -> not_found error.
+    let err = client
+        .call_tool(
+            CallToolRequestParams::new("update_issue")
+                .with_arguments(rmcp::object!({"key": "AUTH-999", "title": "x"})),
+        )
+        .await;
+    assert!(err.is_err(), "expected error for unknown key, got: {err:?}");
+
+    // Unknown status name -> error.
+    let err = client
+        .call_tool(
+            CallToolRequestParams::new("update_issue")
+                .with_arguments(rmcp::object!({"key": "AUTH-1", "status": "Nope"})),
+        )
+        .await;
+    assert!(
+        err.is_err(),
+        "expected error for unknown status, got: {err:?}"
+    );
+
+    client.cancel().await.unwrap();
+    server_handle
+        .await
+        .expect("server task panicked")
+        .expect("server task errored");
+}
+
+#[tokio::test]
 async fn list_statuses_and_labels() {
     let dir = tempfile::tempdir().unwrap();
     let mut ws = Workspace::open(&dir.path().join("data.db")).unwrap();

--- a/crates/kanban-mcp/tests/stdio_smoke.rs
+++ b/crates/kanban-mcp/tests/stdio_smoke.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 use kanban_core::Workspace;
-use kanban_core::operation::{CreateProject, Operation};
+use kanban_core::operation::{CreateIssue, CreateProject, Operation};
+use kanban_core::types::Priority;
 use kanban_mcp::server::KanbanServer;
 use rmcp::{ClientHandler, ServiceExt, model::CallToolRequestParams};
 use uuid::Uuid;
@@ -47,6 +48,131 @@ async fn lists_tools_and_calls_list_projects() {
         .expect("first content block is text");
     let parsed: serde_json::Value = serde_json::from_str(&text.text).unwrap();
     assert_eq!(parsed[0]["prefix"], "AUTH", "got: {parsed}");
+
+    client.cancel().await.unwrap();
+    server_handle
+        .await
+        .expect("server task panicked")
+        .expect("server task errored");
+}
+
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn issue_read_tools() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut ws = Workspace::open(&dir.path().join("data.db")).unwrap();
+    let project_id = Uuid::now_v7();
+    ws.apply(Operation::CreateProject(CreateProject {
+        id: project_id,
+        name: "Auth".into(),
+        prefix: "AUTH".into(),
+        description: None,
+        icon: None,
+    }))
+    .unwrap();
+
+    // First default status is "Todo".
+    let statuses = ws.query_statuses_for_project(project_id).unwrap();
+    let todo = statuses
+        .iter()
+        .find(|s| s.name == "Todo")
+        .expect("a 'Todo' default status");
+
+    ws.apply(Operation::CreateIssue(CreateIssue {
+        id: Uuid::now_v7(),
+        project_id,
+        title: "Implement login flow".into(),
+        description: Some("OAuth handshake details".into()),
+        status_id: todo.id,
+        priority: Priority::High,
+        due_date: None,
+        label_ids: vec![],
+    }))
+    .unwrap();
+
+    let server = KanbanServer::with_workspace(ws);
+    let (server_t, client_t) = tokio::io::duplex(8192);
+
+    let server_handle = tokio::spawn(async move {
+        let svc = server.serve(server_t).await?;
+        svc.waiting().await?;
+        anyhow::Ok(())
+    });
+
+    let client = TestClient.serve(client_t).await.unwrap();
+
+    let tools = client.list_all_tools().await.unwrap();
+    assert!(tools.iter().any(|t| t.name == "list_issues"));
+    assert!(tools.iter().any(|t| t.name == "get_issue"));
+    assert!(tools.iter().any(|t| t.name == "search_issues"));
+
+    // list_issues: the issue appears, status is the NAME ("Todo").
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("list_issues")
+                .with_arguments(rmcp::object!({"project": "AUTH"})),
+        )
+        .await
+        .unwrap();
+    let text = result.content[0]
+        .as_text()
+        .expect("first content block is text");
+    let parsed: serde_json::Value = serde_json::from_str(&text.text).unwrap();
+    let issues = parsed.as_array().expect("issues is an array");
+    assert_eq!(issues.len(), 1, "got: {parsed}");
+    assert_eq!(issues[0]["key"], "AUTH-1", "got: {parsed}");
+    assert_eq!(issues[0]["title"], "Implement login flow", "got: {parsed}");
+    assert_eq!(issues[0]["status"], "Todo", "got: {parsed}");
+    assert_eq!(issues[0]["priority"], "high", "got: {parsed}");
+
+    // get_issue: by key, including description + status name.
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("get_issue")
+                .with_arguments(rmcp::object!({"key": "AUTH-1"})),
+        )
+        .await
+        .unwrap();
+    let text = result.content[0]
+        .as_text()
+        .expect("first content block is text");
+    let parsed: serde_json::Value = serde_json::from_str(&text.text).unwrap();
+    assert_eq!(parsed["title"], "Implement login flow", "got: {parsed}");
+    assert_eq!(parsed["status"], "Todo", "got: {parsed}");
+    assert_eq!(
+        parsed["description"], "OAuth handshake details",
+        "got: {parsed}"
+    );
+
+    // search_issues: a word from the title matches.
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("search_issues")
+                .with_arguments(rmcp::object!({"query": "login"})),
+        )
+        .await
+        .unwrap();
+    let text = result.content[0]
+        .as_text()
+        .expect("first content block is text");
+    let parsed: serde_json::Value = serde_json::from_str(&text.text).unwrap();
+    let issues = parsed.as_array().expect("issues is an array");
+    assert!(
+        issues.iter().any(|i| i["key"] == "AUTH-1"),
+        "expected AUTH-1 in search results, got: {parsed}"
+    );
+
+    // list_issues with an unknown status name surfaces a tool error.
+    let err = client
+        .call_tool(
+            CallToolRequestParams::new("list_issues")
+                .with_arguments(rmcp::object!({"project": "AUTH", "status": "NoSuchStatus"})),
+        )
+        .await;
+    assert!(
+        err.is_err(),
+        "expected error for unknown status, got: {err:?}"
+    );
 
     client.cancel().await.unwrap();
     server_handle

--- a/crates/kanban-mcp/tests/stdio_smoke.rs
+++ b/crates/kanban-mcp/tests/stdio_smoke.rs
@@ -54,3 +54,84 @@ async fn lists_tools_and_calls_list_projects() {
         .expect("server task panicked")
         .expect("server task errored");
 }
+
+#[tokio::test]
+async fn list_statuses_and_labels() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut ws = Workspace::open(&dir.path().join("data.db")).unwrap();
+    ws.apply(Operation::CreateProject(CreateProject {
+        id: Uuid::now_v7(),
+        name: "Auth".into(),
+        prefix: "AUTH".into(),
+        description: None,
+        icon: None,
+    }))
+    .unwrap();
+
+    let server = KanbanServer::with_workspace(ws);
+    let (server_t, client_t) = tokio::io::duplex(8192);
+
+    let server_handle = tokio::spawn(async move {
+        let svc = server.serve(server_t).await?;
+        svc.waiting().await?;
+        anyhow::Ok(())
+    });
+
+    let client = TestClient.serve(client_t).await.unwrap();
+
+    let tools = client.list_all_tools().await.unwrap();
+    assert!(tools.iter().any(|t| t.name == "list_statuses"));
+    assert!(tools.iter().any(|t| t.name == "list_labels"));
+
+    // A fresh project seeds 7 default statuses; assert the array is non-empty
+    // and contains a known default name.
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("list_statuses")
+                .with_arguments(rmcp::object!({"project": "AUTH"})),
+        )
+        .await
+        .unwrap();
+    let text = result.content[0]
+        .as_text()
+        .expect("first content block is text");
+    let parsed: serde_json::Value = serde_json::from_str(&text.text).unwrap();
+    let statuses = parsed.as_array().expect("statuses is an array");
+    assert_eq!(statuses.len(), 7, "got: {parsed}");
+    assert!(
+        statuses.iter().any(|s| s["name"] == "In Progress"),
+        "expected an 'In Progress' status, got: {parsed}"
+    );
+
+    // Labels: a fresh project has none, so an empty array.
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("list_labels")
+                .with_arguments(rmcp::object!({"project": "AUTH"})),
+        )
+        .await
+        .unwrap();
+    let text = result.content[0]
+        .as_text()
+        .expect("first content block is text");
+    let parsed: serde_json::Value = serde_json::from_str(&text.text).unwrap();
+    assert!(parsed.as_array().expect("labels is an array").is_empty());
+
+    // Unknown project surfaces a tool error (JSON-RPC error -> Err).
+    let err = client
+        .call_tool(
+            CallToolRequestParams::new("list_statuses")
+                .with_arguments(rmcp::object!({"project": "NOPE"})),
+        )
+        .await;
+    assert!(
+        err.is_err(),
+        "expected error for unknown project, got: {err:?}"
+    );
+
+    client.cancel().await.unwrap();
+    server_handle
+        .await
+        .expect("server task panicked")
+        .expect("server task errored");
+}

--- a/crates/kanban-mcp/tests/stdio_smoke.rs
+++ b/crates/kanban-mcp/tests/stdio_smoke.rs
@@ -182,6 +182,73 @@ async fn issue_read_tools() {
 }
 
 #[tokio::test]
+async fn create_project_tool() {
+    // Start from an EMPTY workspace (no seed project).
+    let dir = tempfile::tempdir().unwrap();
+    let ws = Workspace::open(&dir.path().join("data.db")).unwrap();
+
+    let server = KanbanServer::with_workspace(ws);
+    let (server_t, client_t) = tokio::io::duplex(8192);
+
+    let server_handle = tokio::spawn(async move {
+        let svc = server.serve(server_t).await?;
+        svc.waiting().await?;
+        anyhow::Ok(())
+    });
+
+    let client = TestClient.serve(client_t).await.unwrap();
+
+    let tools = client.list_all_tools().await.unwrap();
+    assert!(tools.iter().any(|t| t.name == "create_project"));
+
+    // Valid create succeeds and echoes the prefix.
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("create_project")
+                .with_arguments(rmcp::object!({"name": "Auth Service", "prefix": "AUTH"})),
+        )
+        .await
+        .unwrap();
+    let text = result.content[0]
+        .as_text()
+        .expect("first content block is text");
+    assert!(text.text.contains("AUTH"), "got: {}", text.text);
+
+    // list_projects now contains the created project.
+    let result = client
+        .call_tool(CallToolRequestParams::new("list_projects"))
+        .await
+        .unwrap();
+    let text = result.content[0]
+        .as_text()
+        .expect("first content block is text");
+    let parsed: serde_json::Value = serde_json::from_str(&text.text).unwrap();
+    let projects = parsed.as_array().expect("projects is an array");
+    assert!(
+        projects.iter().any(|p| p["prefix"] == "AUTH"),
+        "expected a project with prefix AUTH, got: {parsed}"
+    );
+
+    // Invalid prefix (lowercase) is rejected by core validation -> tool error.
+    let err = client
+        .call_tool(
+            CallToolRequestParams::new("create_project")
+                .with_arguments(rmcp::object!({"name": "x", "prefix": "lower"})),
+        )
+        .await;
+    assert!(
+        err.is_err(),
+        "expected error for invalid prefix, got: {err:?}"
+    );
+
+    client.cancel().await.unwrap();
+    server_handle
+        .await
+        .expect("server task panicked")
+        .expect("server task errored");
+}
+
+#[tokio::test]
 async fn list_statuses_and_labels() {
     let dir = tempfile::tempdir().unwrap();
     let mut ws = Workspace::open(&dir.path().join("data.db")).unwrap();

--- a/crates/kanban-tauri/src/commands.rs
+++ b/crates/kanban-tauri/src/commands.rs
@@ -74,23 +74,15 @@ pub fn list_issues_inner(ws: &Workspace, prefix: &str) -> Result<Vec<IssueDto>, 
 /// Get a single issue by its `identifier` (e.g. `AUTH-12`).
 ///
 /// Identifiers are globally unique (prefix is unique per project, seq unique
-/// within a project), so a workspace-wide scan returns the correct row.
-///
-/// FOLLOWUP(perf): this scans all issues then filters in Rust. Fine at desktop
-/// scale; if it ever matters, add `store::read::issues::by_identifier` (indexed
-/// `WHERE identifier = ?1`) to kanban-core and call it here.
+/// within a project), so a workspace-wide lookup returns the correct row.
 ///
 /// # Errors
 ///
 /// Returns `ApiError::NotFound` if no issue has the given identifier, or an
 /// error if the underlying query fails.
 pub fn get_issue_inner(ws: &Workspace, key: &str) -> Result<IssueDto, ApiError> {
-    match ws
-        .query_issues(IssueFilter::default())?
-        .into_iter()
-        .find(|i| i.identifier == key)
-    {
-        Some(i) => Ok(IssueDto::from(i)),
+    match ws.query_issue_by_identifier(key)? {
+        Some(issue) => Ok(IssueDto::from(issue)),
         None => Err(ApiError::NotFound {
             resource: "issue".into(),
             key: key.into(),

--- a/crates/kanban-tauri/src/commands.rs
+++ b/crates/kanban-tauri/src/commands.rs
@@ -20,8 +20,7 @@ use crate::state::AppState;
 
 /// Resolve a project by its `prefix`, returning `None` if no project matches.
 fn project_by_prefix(ws: &Workspace, prefix: &str) -> Result<Option<Project>, ApiError> {
-    let projects = ws.query_projects()?;
-    Ok(projects.into_iter().find(|p| p.prefix == prefix))
+    Ok(ws.query_project_by_prefix(prefix)?)
 }
 
 /// List all projects.

--- a/docs/superpowers/plans/2026-06-05-kanban-v2-spec-3-mcp-server-plan.md
+++ b/docs/superpowers/plans/2026-06-05-kanban-v2-spec-3-mcp-server-plan.md
@@ -1,0 +1,1305 @@
+# Kanban v2 — Spec #3 MCP Server Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a `kanban-mcp` stdio MCP server that exposes `kanban-core` to MCP clients (Claude Desktop, Claude Code) as semantic tools — read the board, create/update/move issues, undo/redo — every write going through `Workspace::apply`.
+
+**Architecture:** A new `crates/kanban-mcp` binary built on `rmcp` 1.7 (official Rust MCP SDK, stdio transport). It holds an `Arc<Mutex<Workspace>>` opened via `Workspace::open_default()` (shares `~/.kanban/data.db` with CLI/GUI). Each async `#[tool]` runs the sync core inside `tokio::task::spawn_blocking` (the proven `kanban-tauri` pattern); the mutex guard never crosses `.await`. Tools speak human identifiers (project `prefix`, issue `key`, status/label by name) and resolve them to core UUIDs internally.
+
+**Tech Stack:** Rust 2024, `rmcp` 1.7 (`server,macros,transport-io`), `schemars` 1.x, `tokio`, `serde`/`serde_json`, `tracing`. Tests: `cargo test` (per-tool handler tests on an in-memory `Workspace`; one in-process `tokio::io::duplex` integration test driving `initialize`/`tools/list`/`tools/call`).
+
+**Spec:** `docs/superpowers/specs/2026-06-05-kanban-v2-spec-3-mcp-server-design.md`
+
+---
+
+## Conventions for every task
+
+- Run cargo via `~/.cargo/bin/cargo` (the `cargo` alias may be absent).
+- Gates that must stay green: `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check`.
+- The workspace sets `clippy::unwrap_used`/`expect_used`/`panic` to **warn**, and CI runs `-D warnings`. In production code use `?`/`map_err`; in test modules add the same allow header the existing tests use (copy from an existing `crates/kanban-core/tests/*.rs`, e.g. `#![allow(clippy::unwrap_used)]`, and `#[allow(clippy::panic)]` on a test mod that uses `panic!`).
+- **No `Co-Authored-By` / AI-attribution lines in commits, ever.** Use the exact commit messages given.
+
+## File structure
+
+```
+crates/kanban-mcp/
+├── Cargo.toml
+└── src/
+    ├── main.rs        # tracing→stderr, build KanbanServer, serve(stdio()).waiting()
+    ├── server.rs      # KanbanServer: Arc<Mutex<Workspace>>, ToolRouter, blocking() helper, ServerHandler, all #[tool]s
+    ├── convert.rs     # output DTOs (ProjectOut/IssueOut/StatusOut/LabelOut) + From<core type>, status-name maps
+    ├── inputs.rs      # tool input structs (serde::Deserialize + schemars::JsonSchema)
+    └── error.rs       # kanban_core::Error -> rmcp::ErrorData mapping + resolution-miss helpers
+crates/kanban-mcp/tests/
+    └── stdio_smoke.rs # in-process duplex integration test
+crates/kanban-core/src/workspace.rs   # +query_project_by_prefix, +query_issue_by_identifier
+crates/kanban-tauri/src/commands.rs   # get_issue_inner switches to the new core helper (debt retirement)
+```
+
+---
+
+## Phase 0 — Crate scaffold
+
+### Task 1: Add the `kanban-mcp` crate to the workspace
+
+**Files:**
+- Modify: `Cargo.toml` (workspace members + workspace deps)
+- Create: `crates/kanban-mcp/Cargo.toml`
+- Create: `crates/kanban-mcp/src/main.rs`
+
+- [ ] **Step 1: Add the crate to workspace members + add the new workspace deps**
+
+Edit the root `Cargo.toml`. Add `crates/kanban-mcp` to `members`. Add these to `[workspace.dependencies]` (keep all existing entries unchanged):
+
+```toml
+# new for kanban-mcp
+rmcp = { version = "1.7", features = ["server", "macros", "transport-io"] }
+schemars = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+```
+
+(`tokio`, `serde`, `serde_json`, `anyhow`, `thiserror`, `chrono`, `uuid` already exist in `[workspace.dependencies]` from Spec #2 — reuse them.)
+
+- [ ] **Step 2: Create `crates/kanban-mcp/Cargo.toml`**
+
+```toml
+[package]
+name = "kanban-mcp"
+version = "0.0.1"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Stdio MCP server exposing kanban-core to AI assistants."
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "kanban-mcp"
+path = "src/main.rs"
+
+[dependencies]
+kanban-core = { path = "../kanban-core" }
+rmcp = { workspace = true }
+schemars = { workspace = true }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+# the `client` feature gives an in-process client for the integration test
+rmcp = { version = "1.7", features = ["server", "macros", "transport-io", "client"] }
+tempfile = { workspace = true }
+```
+
+Note: `tokio` in `[workspace.dependencies]` was added in Spec #2 as `{ version = "1", features = ["rt-multi-thread", "macros", "sync"] }`. `rmcp` stdio also needs `tokio` feature `io-std`. Add `io-std` (and `io-util` for the duplex test) to the workspace `tokio` features: change it to `features = ["rt-multi-thread", "macros", "sync", "io-std", "io-util", "signal"]`. Verify `kanban-tauri` still builds after this (only adds features, so it will).
+
+- [ ] **Step 3: Create a minimal `crates/kanban-mcp/src/main.rs`** (compiles; real server lands in Task 4)
+
+```rust
+//! Stdio MCP server for kanban-core. Real implementation lands in later tasks.
+fn main() {
+    eprintln!("kanban-mcp: not yet implemented");
+}
+```
+
+- [ ] **Step 4: Verify the workspace resolves and builds**
+
+Run: `~/.cargo/bin/cargo check --workspace`
+Expected: success — `rmcp` and friends resolve. If `rmcp = "1.7"` does not resolve to a `1.7.x`, pick the latest published `1.x` and note it (the macro/API in this plan targets `rmcp` 1.x — do NOT use a `0.x` version, the macro shape differs).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/kanban-mcp
+git commit -m "chore(mcp): scaffold kanban-mcp crate in workspace"
+```
+
+---
+
+## Phase 1 — Core resolution helpers
+
+### Task 2: `query_project_by_prefix` + `query_issue_by_identifier` (test-first) + retire Tauri scan debt
+
+**Files:**
+- Modify: `crates/kanban-core/src/workspace.rs` (add two methods)
+- Create: `crates/kanban-core/tests/resolution.rs`
+- Modify: `crates/kanban-tauri/src/commands.rs` (`get_issue_inner` uses the new helper)
+
+Context: `projects.prefix` has `idx_projects_prefix` (UNIQUE) and `issues.identifier` has a `UNIQUE` constraint — both lookups are indexed, no migration needed. The existing store layer is `crate::store::read::{projects,issues}`; the existing `Workspace::query_project_by_id` calls `crate::store::read::projects::by_id(&self.conn, id)`. Mirror that style.
+
+- [ ] **Step 1: Write the failing test** `crates/kanban-core/tests/resolution.rs`
+
+Copy the clippy-allow header from an existing file in `crates/kanban-core/tests/` (e.g. `#![allow(clippy::unwrap_used)]`). Use the real `Operation`/`CreateProject`/`CreateIssue` shapes (5-field CreateProject; CreateIssue needs id, project_id, title, description, status_id, priority, due_date, label_ids). Seed via `Workspace::apply`.
+
+```rust
+#![allow(clippy::unwrap_used)]
+use kanban_core::operation::{CreateProject, Operation};
+use kanban_core::Workspace;
+use uuid::Uuid;
+
+#[test]
+fn project_by_prefix_hit_and_miss() {
+    let mut ws = Workspace::open_in_memory().unwrap();
+    let id = Uuid::now_v7();
+    ws.apply(Operation::CreateProject(CreateProject {
+        id,
+        name: "Auth Service".into(),
+        prefix: "AUTH".into(),
+        description: None,
+        icon: None,
+    }))
+    .unwrap();
+
+    let hit = ws.query_project_by_prefix("AUTH").unwrap();
+    assert_eq!(hit.map(|p| p.id), Some(id));
+    assert!(ws.query_project_by_prefix("NOPE").unwrap().is_none());
+}
+```
+
+For the issue test, after creating the project, create an issue and assert `query_issue_by_identifier` finds it by its `identifier` (the issue's `identifier` is assigned by core, e.g. `AUTH-1`). To get a valid `status_id`, read the project's statuses with `ws.query_statuses_for_project(project_id)` and use the first. Add:
+
+```rust
+#[test]
+fn issue_by_identifier_hit_and_miss() {
+    use kanban_core::operation::CreateIssue;
+    use kanban_core::types::Priority;
+
+    let mut ws = Workspace::open_in_memory().unwrap();
+    let pid = Uuid::now_v7();
+    ws.apply(Operation::CreateProject(CreateProject {
+        id: pid,
+        name: "Auth".into(),
+        prefix: "AUTH".into(),
+        description: None,
+        icon: None,
+    }))
+    .unwrap();
+    let status_id = ws.query_statuses_for_project(pid).unwrap()[0].id;
+
+    let iid = Uuid::now_v7();
+    ws.apply(Operation::CreateIssue(CreateIssue {
+        id: iid,
+        project_id: pid,
+        title: "Add OAuth".into(),
+        description: None,
+        status_id,
+        priority: Priority::Medium,
+        due_date: None,
+        label_ids: vec![],
+    }))
+    .unwrap();
+
+    let issue = ws.query_issue_by_identifier("AUTH-1").unwrap();
+    assert_eq!(issue.map(|i| i.id), Some(iid));
+    assert!(ws.query_issue_by_identifier("AUTH-999").unwrap().is_none());
+}
+```
+
+- [ ] **Step 2: Run the test, confirm it FAILS to compile** (`no method named query_project_by_prefix`)
+
+Run: `~/.cargo/bin/cargo test -p kanban-core --test resolution`
+Expected: compile failure.
+
+- [ ] **Step 3: Add the two read methods to `impl Workspace`** in `crates/kanban-core/src/workspace.rs`
+
+Add `pub(crate)` store functions if you prefer to match the layering, but the smallest correct change is two inline indexed queries (the settings accessors from Spec #2 set the precedent for inline queries on `Workspace`). Use `rusqlite::OptionalExtension`.
+
+```rust
+/// Look up a project by its unique `prefix`. Returns `Ok(None)` if absent.
+///
+/// # Errors
+/// Returns a database error if the read fails.
+pub fn query_project_by_prefix(
+    &self,
+    prefix: &str,
+) -> crate::error::Result<Option<crate::types::Project>> {
+    use rusqlite::OptionalExtension;
+    let id: Option<uuid::Uuid> = self
+        .conn
+        .query_row(
+            "SELECT id FROM projects WHERE prefix = ?1",
+            [prefix],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|s| uuid::Uuid::parse_str(&s))
+        .transpose()
+        .map_err(|e| crate::error::Error::InvalidSnapshot(format!("bad project uuid: {e}")))?;
+    match id {
+        Some(id) => Ok(Some(self.query_project_by_id(id)?)),
+        None => Ok(None),
+    }
+}
+
+/// Look up an issue by its unique `identifier` (e.g. `AUTH-12`). Returns `Ok(None)` if absent.
+///
+/// # Errors
+/// Returns a database error if the read fails.
+pub fn query_issue_by_identifier(
+    &self,
+    identifier: &str,
+) -> crate::error::Result<Option<crate::types::Issue>> {
+    use rusqlite::OptionalExtension;
+    let id: Option<uuid::Uuid> = self
+        .conn
+        .query_row(
+            "SELECT id FROM issues WHERE identifier = ?1",
+            [identifier],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .map(|s| uuid::Uuid::parse_str(&s))
+        .transpose()
+        .map_err(|e| crate::error::Error::InvalidSnapshot(format!("bad issue uuid: {e}")))?;
+    match id {
+        Some(id) => Ok(Some(self.query_issue_by_id(id)?)),
+        None => Ok(None),
+    }
+}
+```
+
+(If the `projects.id`/`issues.id` columns store UUIDs as TEXT, the parse above is correct. Confirm by checking how `query_project_by_id` reads ids in `crate::store::read::projects`; match its uuid handling. If the store already exposes a `by_prefix`/`by_identifier`, call that instead and delete the inline SQL.)
+
+- [ ] **Step 4: Run the test, confirm PASS**
+
+Run: `~/.cargo/bin/cargo test -p kanban-core --test resolution`
+Expected: 2 pass.
+
+- [ ] **Step 5: Retire the Tauri scan debt** — in `crates/kanban-tauri/src/commands.rs`, change `get_issue_inner` to use the new helper:
+
+```rust
+pub fn get_issue_inner(ws: &Workspace, key: &str) -> Result<IssueDto, ApiError> {
+    match ws.query_issue_by_identifier(key)? {
+        Some(issue) => Ok(IssueDto::from(issue)),
+        None => Err(ApiError::NotFound {
+            resource: "issue".into(),
+            key: key.into(),
+        }),
+    }
+}
+```
+
+Remove the now-stale `FOLLOWUP(perf)` comment above it. (The `?` works because `From<kanban_core::Error> for ApiError` exists.)
+
+- [ ] **Step 6: Verify nothing regressed**
+
+Run: `~/.cargo/bin/cargo test --workspace` → all pass (kanban-tauri's existing `get_issue` tests still green).
+Run: `~/.cargo/bin/cargo clippy --workspace --all-targets -- -D warnings` → clean.
+Run: `~/.cargo/bin/cargo fmt --all -- --check` → clean (`cargo fmt --all` first if needed).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/kanban-core/src/workspace.rs crates/kanban-core/tests/resolution.rs crates/kanban-tauri/src/commands.rs
+git commit -m "feat(core): add prefix/identifier resolution helpers; retire tauri get_issue scan"
+```
+
+---
+
+## Phase 2 — Error mapping + server skeleton
+
+### Task 3: `kanban_core::Error` → `rmcp::ErrorData` mapping (test-first)
+
+**Files:**
+- Create: `crates/kanban-mcp/src/error.rs`
+- Modify: `crates/kanban-mcp/src/main.rs` (declare `mod error;` — temporary until Task 4 restructures)
+
+- [ ] **Step 1: Write `crates/kanban-mcp/src/error.rs`** with the mapping + helpers + inline tests
+
+```rust
+//! Map kanban-core errors (and resolution misses) to MCP tool errors.
+use rmcp::ErrorData as McpError;
+
+/// Convert a `kanban_core::Error` into an MCP tool error with an LLM-actionable message.
+pub fn to_mcp(err: kanban_core::Error) -> McpError {
+    use kanban_core::Error;
+    match err {
+        Error::NotFound { kind, id } => {
+            McpError::resource_not_found(format!("{kind} not found: {id}"), None)
+        }
+        Error::Validation(v) => {
+            McpError::invalid_params(format!("{}: {}", v.field, v.reason), None)
+        }
+        Error::Conflict(msg) => McpError::invalid_request(msg, None),
+        Error::Db(e) => McpError::internal_error(format!("db: {e}"), None),
+        Error::Io(e) => McpError::internal_error(format!("io: {e}"), None),
+        Error::Serde(e) => McpError::internal_error(format!("serde: {e}"), None),
+        Error::InvalidSnapshot(s) => McpError::invalid_params(format!("snapshot: {s}"), None),
+    }
+}
+
+/// A "not found by human identifier" error (project prefix / issue key).
+pub fn not_found(resource: &str, key: &str) -> McpError {
+    McpError::resource_not_found(format!("{resource} not found: {key}"), None)
+}
+
+/// A "name not found within a project" error that lists the valid options.
+pub fn unknown_name(kind: &str, name: &str, project: &str, available: &[String]) -> McpError {
+    McpError::invalid_params(
+        format!(
+            "{kind} '{name}' not found in project {project}; available: {}",
+            available.join(", ")
+        ),
+        None,
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validation_maps_to_invalid_params_with_field() {
+        let err = kanban_core::Error::Validation(kanban_core::ValidationError {
+            field: "prefix".into(),
+            reason: "must be 2-8 uppercase letters".into(),
+        });
+        let mcp = to_mcp(err);
+        assert!(mcp.message.contains("prefix"));
+        assert!(mcp.message.contains("uppercase"));
+    }
+
+    #[test]
+    fn unknown_name_lists_available() {
+        let mcp = unknown_name("status", "Doing", "AUTH", &["To Do".into(), "Done".into()]);
+        assert!(mcp.message.contains("Doing"));
+        assert!(mcp.message.contains("To Do, Done"));
+    }
+}
+```
+
+(Confirm `McpError`/`ErrorData` exposes a public `message` field for the asserts; rmcp 1.7's `ErrorData` has `code`, `message: Cow<'static, str>`, `data`. If `message` is not directly accessible, assert via `format!("{mcp:?}")` containing the substrings instead.)
+
+- [ ] **Step 2: Wire `mod error;` into `main.rs`** (replace the Task 1 stub body — keep `fn main` minimal):
+
+```rust
+mod error;
+
+fn main() {
+    eprintln!("kanban-mcp: not yet implemented");
+}
+```
+
+(`mod error` is unused by `main` yet; if clippy flags `dead_code` on the helpers, that's fine — they're used from Task 4 onward in the same crate. If `-D warnings` fails on dead_code now, add `#![allow(dead_code)]` at the top of `error.rs` with a comment that Task 4 consumes it, and remove it in Task 4.)
+
+- [ ] **Step 3: Test + gates**
+
+Run: `~/.cargo/bin/cargo test -p kanban-mcp` → 2 pass.
+Run: `~/.cargo/bin/cargo clippy -p kanban-mcp --all-targets -- -D warnings` → clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/kanban-mcp/src/error.rs crates/kanban-mcp/src/main.rs
+git commit -m "feat(mcp): add kanban-core error to MCP error mapping"
+```
+
+---
+
+### Task 4: Server skeleton + `list_projects` tool + stdio integration test
+
+This task stands the whole pipeline up end-to-end with one read tool, proven by an in-process integration test.
+
+**Files:**
+- Create: `crates/kanban-mcp/src/server.rs`
+- Create: `crates/kanban-mcp/src/convert.rs`
+- Create: `crates/kanban-mcp/src/inputs.rs` (empty-ish for now; `list_projects` has no params)
+- Rewrite: `crates/kanban-mcp/src/main.rs`
+- Create: `crates/kanban-mcp/tests/stdio_smoke.rs`
+
+- [ ] **Step 1: Create `crates/kanban-mcp/src/convert.rs`** — output DTOs (clean, human-facing; no UUIDs, no `sort_key`)
+
+```rust
+//! Output shapes returned to the MCP client. Human-facing: prefixes/keys/names,
+//! never UUIDs or sort keys.
+use kanban_core::types::{Issue, Label, Project, Status};
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct ProjectOut {
+    pub prefix: String,
+    pub name: String,
+    pub description: Option<String>,
+}
+impl From<Project> for ProjectOut {
+    fn from(p: Project) -> Self {
+        Self { prefix: p.prefix, name: p.name, description: p.description }
+    }
+}
+
+#[derive(Serialize)]
+pub struct StatusOut {
+    pub name: String,
+    pub category: String,
+}
+impl From<Status> for StatusOut {
+    fn from(s: Status) -> Self {
+        Self { name: s.name, category: s.category.as_str().to_owned() }
+    }
+}
+
+#[derive(Serialize)]
+pub struct LabelOut {
+    pub name: String,
+    pub color: String,
+}
+impl From<Label> for LabelOut {
+    fn from(l: Label) -> Self {
+        Self { name: l.name, color: l.color }
+    }
+}
+
+#[derive(Serialize)]
+pub struct IssueOut {
+    pub key: String,
+    pub title: String,
+    pub status: String, // status NAME
+    pub priority: String,
+    pub due_date: Option<String>,
+    pub description: Option<String>,
+}
+
+impl IssueOut {
+    /// Build from a core `Issue` plus a status-id→name map for the issue's project.
+    pub fn from_issue(i: Issue, status_name: &str) -> Self {
+        Self {
+            key: i.identifier,
+            title: i.title,
+            status: status_name.to_owned(),
+            priority: i.priority.as_str().to_owned(),
+            due_date: i.due_date.map(|d| d.to_string()),
+            description: i.description,
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Create `crates/kanban-mcp/src/inputs.rs`** (input structs land here; start with the ones used so far — none for `list_projects`, so just a module doc for now)
+
+```rust
+//! Tool input parameter structs (serde::Deserialize + schemars::JsonSchema).
+//! Populated as tools are added.
+```
+
+- [ ] **Step 3: Create `crates/kanban-mcp/src/server.rs`** — the server, the `blocking()` helper, `ServerHandler`, and `list_projects`
+
+```rust
+use std::sync::{Arc, Mutex};
+
+use rmcp::{
+    handler::server::router::tool::ToolRouter,
+    model::{CallToolResult, Content, Implementation, ProtocolVersion, ServerCapabilities, ServerInfo},
+    tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler,
+};
+
+use kanban_core::Workspace;
+
+use crate::convert::ProjectOut;
+use crate::error::to_mcp;
+
+#[derive(Clone)]
+pub struct KanbanServer {
+    workspace: Arc<Mutex<Workspace>>,
+    tool_router: ToolRouter<KanbanServer>,
+}
+
+impl KanbanServer {
+    /// Open the default workspace (`~/.kanban/data.db` or `$KANBAN_DB`).
+    ///
+    /// # Errors
+    /// Returns an error if the workspace cannot be opened.
+    pub fn from_default() -> anyhow::Result<Self> {
+        let ws = Workspace::open_default()?;
+        Ok(Self::with_workspace(ws))
+    }
+
+    /// Build a server around an already-open workspace (used by tests).
+    #[must_use]
+    pub fn with_workspace(ws: Workspace) -> Self {
+        Self {
+            workspace: Arc::new(Mutex::new(ws)),
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    /// Run a sync closure against the workspace on a blocking thread, never
+    /// holding the mutex guard across `.await`. Maps core errors to MCP errors.
+    async fn blocking<T, F>(&self, f: F) -> Result<T, McpError>
+    where
+        T: Send + 'static,
+        F: FnOnce(&mut Workspace) -> Result<T, kanban_core::Error> + Send + 'static,
+    {
+        let ws = Arc::clone(&self.workspace);
+        tokio::task::spawn_blocking(move || {
+            let mut guard = ws
+                .lock()
+                .map_err(|_| kanban_core::Error::Conflict("workspace mutex poisoned".into()))?;
+            f(&mut guard)
+        })
+        .await
+        .map_err(|e| McpError::internal_error(format!("task join error: {e}"), None))?
+        .map_err(to_mcp)
+    }
+}
+
+/// Serialize a value to a pretty JSON text content block.
+pub(crate) fn json_content<T: serde::Serialize>(value: &T) -> Result<CallToolResult, McpError> {
+    let text = serde_json::to_string_pretty(value)
+        .map_err(|e| McpError::internal_error(format!("serialize: {e}"), None))?;
+    Ok(CallToolResult::success(vec![Content::text(text)]))
+}
+
+#[tool_router]
+impl KanbanServer {
+    #[tool(description = "List all projects (prefix, name, description).")]
+    async fn list_projects(&self) -> Result<CallToolResult, McpError> {
+        let projects = self.blocking(|ws| ws.query_projects()).await?;
+        let out: Vec<ProjectOut> = projects.into_iter().map(ProjectOut::from).collect();
+        json_content(&out)
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for KanbanServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::from_build_env())
+            .with_protocol_version(ProtocolVersion::V_2024_11_05)
+            .with_instructions(
+                "Read and manage a local kanban board. Address projects by prefix (e.g. AUTH) \
+                 and issues by key (e.g. AUTH-12). Statuses and labels are referenced by name."
+                    .to_string(),
+            )
+    }
+}
+```
+
+NOTE on the `blocking` signature: `query_projects` takes `&self`, but `apply`/`undo` take `&mut self`; using `&mut Workspace` in the closure covers both. For read-only tools the `&mut` is harmless.
+
+NOTE on rmcp API surface: the imports above (`rmcp::model::{...}`, `rmcp::{tool, tool_handler, tool_router, ErrorData, ServerHandler}`, `rmcp::handler::server::router::tool::ToolRouter`) match rmcp 1.7. If a path differs in the resolved version, fix the import to the real path (the macro and type names — `tool_router`, `tool_handler`, `ToolRouter`, `Parameters`, `CallToolResult`, `Content`, `ServerInfo`, `ServerCapabilities`, `Implementation`, `ProtocolVersion`, `ErrorData`, `ServerHandler`, `ServiceExt`, `transport::stdio` — are stable in 1.x).
+
+- [ ] **Step 4: Rewrite `crates/kanban-mcp/src/main.rs`**
+
+```rust
+mod convert;
+mod error;
+mod inputs;
+mod server;
+
+use anyhow::Result;
+use rmcp::{transport::stdio, ServiceExt};
+use tracing_subscriber::EnvFilter;
+
+use crate::server::KanbanServer;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // stdout is the JSON-RPC channel — all logging goes to stderr.
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive(tracing::Level::INFO.into()))
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .init();
+
+    let server = KanbanServer::from_default()?;
+    let service = server.serve(stdio()).await?;
+    service.waiting().await?;
+    Ok(())
+}
+```
+
+(`main` now uses `.serve()`/`.waiting()` — real entry point; no `expect`. If clippy still wants an allow somewhere, prefer `?` over `expect`.)
+
+- [ ] **Step 5: Create the in-process integration test** `crates/kanban-mcp/tests/stdio_smoke.rs`
+
+This drives the server with a real in-process client over `tokio::io::duplex`, exercising `initialize` (done by `client.serve`), `tools/list`, and a `list_projects` call against a temp-DB workspace.
+
+```rust
+#![allow(clippy::unwrap_used)]
+use kanban_core::operation::{CreateProject, Operation};
+use kanban_core::Workspace;
+use kanban_mcp::server::KanbanServer; // requires a lib target — see note below
+use rmcp::{model::CallToolRequestParam, ClientHandler, ServiceExt};
+use uuid::Uuid;
+
+#[derive(Default, Clone)]
+struct TestClient;
+impl ClientHandler for TestClient {}
+
+#[tokio::test]
+async fn lists_tools_and_calls_list_projects() {
+    // Seed a temp workspace with one project.
+    let dir = tempfile::tempdir().unwrap();
+    let mut ws = Workspace::open(&dir.path().join("data.db")).unwrap();
+    ws.apply(Operation::CreateProject(CreateProject {
+        id: Uuid::now_v7(),
+        name: "Auth".into(),
+        prefix: "AUTH".into(),
+        description: None,
+        icon: None,
+    }))
+    .unwrap();
+
+    let server = KanbanServer::with_workspace(ws);
+    let (server_t, client_t) = tokio::io::duplex(8192);
+
+    let server_handle = tokio::spawn(async move {
+        let svc = server.serve(server_t).await?;
+        svc.waiting().await?;
+        anyhow::Ok(())
+    });
+
+    let client = TestClient.serve(client_t).await.unwrap();
+
+    let tools = client.list_all_tools().await.unwrap();
+    assert!(tools.iter().any(|t| t.name == "list_projects"));
+
+    let result = client
+        .call_tool(CallToolRequestParam { name: "list_projects".into(), arguments: None })
+        .await
+        .unwrap();
+    let text = format!("{:?}", result.content);
+    assert!(text.contains("AUTH"));
+
+    client.cancel().await.unwrap();
+    let _ = server_handle.await;
+}
+```
+
+**Note — lib target:** the integration test imports `kanban_mcp::server::KanbanServer`, which requires `kanban-mcp` to expose a library, not just a binary. Add a `src/lib.rs` exposing the modules and make `main.rs` use the lib:
+
+- Create `crates/kanban-mcp/src/lib.rs`:
+  ```rust
+  pub mod convert;
+  pub mod error;
+  pub mod inputs;
+  pub mod server;
+  ```
+- Add to `Cargo.toml`: `[lib]\nname = "kanban_mcp"\npath = "src/lib.rs"` (keep the `[[bin]]`).
+- Change `main.rs` to drop the `mod` declarations and use `kanban_mcp::server::KanbanServer` (mirrors how `kanban-tauri` is lib+bin).
+
+- [ ] **Step 6: Run the integration test + gates**
+
+Run: `~/.cargo/bin/cargo test -p kanban-mcp` → the error tests + `lists_tools_and_calls_list_projects` pass.
+Run: `~/.cargo/bin/cargo clippy --workspace --all-targets -- -D warnings` → clean.
+Run: `~/.cargo/bin/cargo fmt --all -- --check` → clean.
+
+If `client.serve`/`list_all_tools`/`call_tool`/`CallToolRequestParam`/`result.content` differ in the resolved rmcp version, adjust to the real client API (the in-process duplex approach itself is stable). If the handshake needs an explicit protocol version, pass it; the defaults should suffice.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/kanban-mcp Cargo.toml Cargo.lock
+git commit -m "feat(mcp): stdio server skeleton with list_projects and in-process smoke test"
+```
+
+---
+
+## Phase 3 — Read tools
+
+For every tool below: add the `#[tool]` method to the `#[tool_router] impl KanbanServer` block in `server.rs`, add its input struct (if any) to `inputs.rs`, extend the integration test (or add a focused `#[tokio::test]`) to call it, run gates, commit. Each tool resolves human identifiers via the Task 2 helpers and returns `json_content(&out)`.
+
+### Task 5: `list_statuses` + `list_labels`
+
+**Files:** Modify `crates/kanban-mcp/src/server.rs`, `crates/kanban-mcp/src/inputs.rs`, `crates/kanban-mcp/tests/stdio_smoke.rs`.
+
+- [ ] **Step 1: Add the input struct** to `inputs.rs`
+
+```rust
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ProjectRef {
+    /// Project prefix, e.g. "AUTH".
+    pub project: String,
+}
+```
+
+- [ ] **Step 2: Add the tools** to the `#[tool_router] impl KanbanServer` block
+
+```rust
+#[tool(description = "List the status columns of a project, in board order. `project` is the prefix, e.g. AUTH.")]
+async fn list_statuses(
+    &self,
+    rmcp::handler::server::wrapper::Parameters(args): rmcp::handler::server::wrapper::Parameters<crate::inputs::ProjectRef>,
+) -> Result<CallToolResult, McpError> {
+    let prefix = args.project.clone();
+    let statuses = self
+        .blocking(move |ws| {
+            let Some(p) = ws.query_project_by_prefix(&prefix)? else {
+                return Ok(None);
+            };
+            Ok(Some(ws.query_statuses_for_project(p.id)?))
+        })
+        .await?;
+    let statuses = statuses.ok_or_else(|| crate::error::not_found("project", &args.project))?;
+    let out: Vec<crate::convert::StatusOut> =
+        statuses.into_iter().map(crate::convert::StatusOut::from).collect();
+    crate::server::json_content(&out)
+}
+
+#[tool(description = "List the labels of a project. `project` is the prefix, e.g. AUTH.")]
+async fn list_labels(
+    &self,
+    rmcp::handler::server::wrapper::Parameters(args): rmcp::handler::server::wrapper::Parameters<crate::inputs::ProjectRef>,
+) -> Result<CallToolResult, McpError> {
+    let prefix = args.project.clone();
+    let labels = self
+        .blocking(move |ws| {
+            let Some(p) = ws.query_project_by_prefix(&prefix)? else {
+                return Ok(None);
+            };
+            Ok(Some(ws.query_labels_for_project(p.id)?))
+        })
+        .await?;
+    let labels = labels.ok_or_else(|| crate::error::not_found("project", &args.project))?;
+    let out: Vec<crate::convert::LabelOut> =
+        labels.into_iter().map(crate::convert::LabelOut::from).collect();
+    crate::server::json_content(&out)
+}
+```
+
+(Tidy the imports — add `use rmcp::handler::server::wrapper::Parameters;` at the top of `server.rs` and use `Parameters(args)` directly instead of the fully-qualified form. Make `json_content` callable — it's already `pub(crate)` in `server.rs`, so call it as `json_content(&out)` from within the same module.)
+
+- [ ] **Step 3: Add a test** (in `stdio_smoke.rs` or a new `#[tokio::test]`): seed the project (a fresh project has 3 default statuses), call `list_statuses` with `{"project":"AUTH"}`, assert the default status names appear. Use `arguments: Some(rmcp::object!({"project":"AUTH"}))`.
+
+- [ ] **Step 4: Gates** (`cargo test -p kanban-mcp`, clippy `--workspace --all-targets -D warnings`, fmt) → green.
+
+- [ ] **Step 5: Commit**
+```bash
+git add crates/kanban-mcp
+git commit -m "feat(mcp): add list_statuses and list_labels tools"
+```
+
+### Task 6: `list_issues` + `get_issue` + `search_issues`
+
+**Files:** Modify `server.rs`, `inputs.rs`, `convert.rs` (a status-name map helper), test file.
+
+- [ ] **Step 1: Add a status-name helper** to `convert.rs`
+
+```rust
+use std::collections::HashMap;
+use uuid::Uuid;
+
+/// Map status id -> status name for a project's statuses.
+pub fn status_name_map(statuses: &[Status]) -> HashMap<Uuid, String> {
+    statuses.iter().map(|s| (s.id, s.name.clone())).collect()
+}
+```
+
+- [ ] **Step 2: Add input structs** to `inputs.rs`
+
+```rust
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListIssues {
+    /// Project prefix, e.g. "AUTH".
+    pub project: String,
+    /// Optional status name to filter by (e.g. "In Progress").
+    #[serde(default)]
+    pub status: Option<String>,
+    /// Optional priority filter: one of none, low, medium, high, urgent.
+    #[serde(default)]
+    pub priority: Option<String>,
+    /// Optional full-text search within the project.
+    #[serde(default)]
+    pub search: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct IssueKey {
+    /// Issue key, e.g. "AUTH-12".
+    pub key: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SearchIssues {
+    /// Full-text query.
+    pub query: String,
+    /// Optional project prefix to scope the search.
+    #[serde(default)]
+    pub project: Option<String>,
+}
+```
+
+- [ ] **Step 3: Implement the tools** in `server.rs`. Use `kanban_core::query::IssueFilter` (has `for_project(uuid)`, `status_ids: Vec<Uuid>`, `priorities: Vec<Priority>`, `search_text: Option<String>`) and `ws.query_issues(filter)` / `ws.search(query, filter)`. For each issue, resolve its `status_id` to a name via the project's `status_name_map`.
+
+`list_issues` — resolve project→id, build a filter (status name → status_id via the project's statuses; `priority` string → `Priority` via `parse`), call `query_issues`, map to `IssueOut` using the status map. On unknown status name return `crate::error::unknown_name(...)`. Concretely:
+
+```rust
+#[tool(description = "List issues in a project. Optionally filter by status name, priority, or a search term.")]
+async fn list_issues(
+    &self,
+    Parameters(args): Parameters<crate::inputs::ListIssues>,
+) -> Result<CallToolResult, McpError> {
+    use kanban_core::query::IssueFilter;
+    use kanban_core::types::Priority;
+
+    let project = args.project.clone();
+    let result = self
+        .blocking(move |ws| {
+            let Some(p) = ws.query_project_by_prefix(&project)? else {
+                return Ok(Err("no_project"));
+            };
+            let statuses = ws.query_statuses_for_project(p.id)?;
+            let mut filter = IssueFilter::for_project(p.id);
+            if let Some(name) = &args.status {
+                match statuses.iter().find(|s| s.name == *name) {
+                    Some(s) => filter.status_ids = vec![s.id],
+                    None => {
+                        let names: Vec<String> = statuses.iter().map(|s| s.name.clone()).collect();
+                        return Ok(Err_unknown("status", name, &project, names));
+                    }
+                }
+            }
+            if let Some(pr) = &args.priority {
+                let parsed: Priority = pr
+                    .parse()
+                    .map_err(|_| kanban_core::Error::Validation(kanban_core::ValidationError {
+                        field: "priority".into(),
+                        reason: "must be one of none, low, medium, high, urgent".into(),
+                    }))?;
+                filter.priorities = vec![parsed];
+            }
+            filter.search_text = args.search.clone();
+            let issues = ws.query_issues(filter)?;
+            let map = crate::convert::status_name_map(&statuses);
+            Ok(Ok((issues, map)))
+        })
+        .await?;
+    // `result` is Result<Ok((issues,map)) | Err(unknown-name/no-project)>; flatten:
+    let (issues, map) = match result {
+        Ok(pair) => pair,
+        Err(e) => return Err(e),
+    };
+    let out: Vec<crate::convert::IssueOut> = issues
+        .into_iter()
+        .map(|i| {
+            let name = map.get(&i.status_id).cloned().unwrap_or_default();
+            crate::convert::IssueOut::from_issue(i, &name)
+        })
+        .collect();
+    json_content(&out)
+}
+```
+
+The inner closure cannot easily return an `McpError` (it returns `kanban_core::Error`). Resolve this cleanly by having the closure return a domain-level enum instead of smuggling `McpError`. Simplest approach: **do resolution in two `blocking` calls** — first resolve the project + statuses, mapping misses to `McpError` outside the closure; then build the filter and query. Rewrite `list_issues` as:
+
+```rust
+#[tool(description = "List issues in a project. Optionally filter by status name, priority, or a search term.")]
+async fn list_issues(
+    &self,
+    Parameters(args): Parameters<crate::inputs::ListIssues>,
+) -> Result<CallToolResult, McpError> {
+    use kanban_core::query::IssueFilter;
+    use kanban_core::types::Priority;
+
+    // 1) resolve project + its statuses
+    let prefix = args.project.clone();
+    let resolved = self
+        .blocking(move |ws| {
+            let Some(p) = ws.query_project_by_prefix(&prefix)? else { return Ok(None) };
+            let statuses = ws.query_statuses_for_project(p.id)?;
+            Ok(Some((p.id, statuses)))
+        })
+        .await?;
+    let (project_id, statuses) =
+        resolved.ok_or_else(|| crate::error::not_found("project", &args.project))?;
+
+    // 2) build filter (name/priority resolution -> McpError here)
+    let mut filter = IssueFilter::for_project(project_id);
+    if let Some(name) = &args.status {
+        let s = statuses.iter().find(|s| &s.name == name).ok_or_else(|| {
+            crate::error::unknown_name(
+                "status",
+                name,
+                &args.project,
+                &statuses.iter().map(|s| s.name.clone()).collect::<Vec<_>>(),
+            )
+        })?;
+        filter.status_ids = vec![s.id];
+    }
+    if let Some(pr) = &args.priority {
+        let parsed: Priority = pr.parse().map_err(|_| {
+            McpError::invalid_params("priority must be one of none, low, medium, high, urgent", None)
+        })?;
+        filter.priorities = vec![parsed];
+    }
+    filter.search_text = args.search.clone();
+
+    // 3) query
+    let issues = self.blocking(move |ws| ws.query_issues(filter)).await?;
+    let map = crate::convert::status_name_map(&statuses);
+    let out: Vec<crate::convert::IssueOut> = issues
+        .into_iter()
+        .map(|i| {
+            let name = map.get(&i.status_id).cloned().unwrap_or_default();
+            crate::convert::IssueOut::from_issue(i, &name)
+        })
+        .collect();
+    json_content(&out)
+}
+```
+
+(Use ONLY this second version — delete the first sketch. The two-phase pattern keeps `McpError` construction out of the `blocking` closure, which can only yield `kanban_core::Error`.)
+
+`get_issue` — resolve the issue by key, then fetch its project's statuses to name the status:
+
+```rust
+#[tool(description = "Get one issue by key (e.g. AUTH-12), including its markdown description.")]
+async fn get_issue(
+    &self,
+    Parameters(args): Parameters<crate::inputs::IssueKey>,
+) -> Result<CallToolResult, McpError> {
+    let key = args.key.clone();
+    let resolved = self
+        .blocking(move |ws| {
+            let Some(issue) = ws.query_issue_by_identifier(&key)? else { return Ok(None) };
+            let statuses = ws.query_statuses_for_project(issue.project_id)?;
+            Ok(Some((issue, statuses)))
+        })
+        .await?;
+    let (issue, statuses) = resolved.ok_or_else(|| crate::error::not_found("issue", &args.key))?;
+    let name = statuses
+        .iter()
+        .find(|s| s.id == issue.status_id)
+        .map(|s| s.name.clone())
+        .unwrap_or_default();
+    json_content(&crate::convert::IssueOut::from_issue(issue, &name))
+}
+```
+
+`search_issues` — optional project scope; use `ws.search(query, filter)`:
+
+```rust
+#[tool(description = "Full-text search issues by title/description. Optionally scope to a project prefix.")]
+async fn search_issues(
+    &self,
+    Parameters(args): Parameters<crate::inputs::SearchIssues>,
+) -> Result<CallToolResult, McpError> {
+    use kanban_core::query::IssueFilter;
+
+    let project = args.project.clone();
+    let resolved = self
+        .blocking(move |ws| {
+            let pid = match &project {
+                Some(prefix) => match ws.query_project_by_prefix(prefix)? {
+                    Some(p) => Some(p.id),
+                    None => return Ok(None), // signal unknown project
+                },
+                None => None,
+            };
+            // collect every project's statuses so we can name statuses across projects
+            let projects = ws.query_projects()?;
+            let mut statuses = Vec::new();
+            for p in &projects {
+                statuses.extend(ws.query_statuses_for_project(p.id)?);
+            }
+            let filter = match pid {
+                Some(id) => IssueFilter::for_project(id),
+                None => IssueFilter::default(),
+            };
+            let issues = ws.search(&args.query, filter)?;
+            Ok(Some((issues, statuses)))
+        })
+        .await?;
+    let (issues, statuses) = match resolved {
+        Some(v) => v,
+        None => return Err(crate::error::not_found("project", args.project.as_deref().unwrap_or(""))),
+    };
+    let map = crate::convert::status_name_map(&statuses);
+    let out: Vec<crate::convert::IssueOut> = issues
+        .into_iter()
+        .map(|i| {
+            let name = map.get(&i.status_id).cloned().unwrap_or_default();
+            crate::convert::IssueOut::from_issue(i, &name)
+        })
+        .collect();
+    json_content(&out)
+}
+```
+
+- [ ] **Step 4: Tests** — add `#[tokio::test]`s (or extend the smoke test): seed a project + an issue (status default), then: `list_issues {project:AUTH}` returns the issue; `get_issue {key:"AUTH-1"}` returns title; `search_issues {query:"<word from title>"}` returns it; unknown status name returns an error mentioning the available statuses.
+
+- [ ] **Step 5: Gates** → green. **Commit**
+```bash
+git add crates/kanban-mcp
+git commit -m "feat(mcp): add list_issues, get_issue, search_issues tools"
+```
+
+---
+
+## Phase 4 — Write tools
+
+Every write tool builds an `Operation` and calls `ws.apply(op)` inside `blocking`. Generate UUIDs with `uuid::Uuid::now_v7()`. Resolve names/keys with the Task 2 helpers + status lookups (two-phase, as in Task 6, to keep `McpError` out of the closure).
+
+### Task 7: `create_project`
+
+**Files:** `inputs.rs`, `server.rs`, test.
+
+- [ ] **Step 1: Input**
+```rust
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CreateProjectInput {
+    /// Display name, e.g. "Auth Service".
+    pub name: String,
+    /// Unique prefix: 2-8 uppercase letters, e.g. "AUTH".
+    pub prefix: String,
+    /// Optional description.
+    #[serde(default)]
+    pub description: Option<String>,
+}
+```
+
+- [ ] **Step 2: Tool** (in `server.rs`)
+```rust
+#[tool(description = "Create a new project. prefix must be 2-8 uppercase letters.")]
+async fn create_project(
+    &self,
+    Parameters(args): Parameters<crate::inputs::CreateProjectInput>,
+) -> Result<CallToolResult, McpError> {
+    use kanban_core::operation::{CreateProject, Operation};
+    let id = uuid::Uuid::now_v7();
+    let prefix = args.prefix.clone();
+    self.blocking(move |ws| {
+        ws.apply(Operation::CreateProject(CreateProject {
+            id,
+            name: args.name,
+            prefix: args.prefix,
+            description: args.description,
+            icon: None,
+        }))
+        .map(|_| ())
+    })
+    .await?;
+    json_content(&serde_json::json!({ "created": prefix }))
+}
+```
+(Core validates the prefix; an invalid one surfaces as `Validation` → `invalid_params` via `to_mcp`.)
+
+- [ ] **Step 3: Test** — call `create_project {name,prefix:"PAY"}`, then `list_projects` includes PAY; an invalid prefix (`"pay"`) returns an `invalid_params` error mentioning "uppercase".
+- [ ] **Step 4: Gates + commit** `feat(mcp): add create_project tool`
+
+### Task 8: `create_issue`
+
+- [ ] **Step 1: Input**
+```rust
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CreateIssueInput {
+    /// Project prefix, e.g. "AUTH".
+    pub project: String,
+    /// Issue title.
+    pub title: String,
+    /// Optional markdown description.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Optional status name; defaults to the project's first column.
+    #[serde(default)]
+    pub status: Option<String>,
+    /// Optional priority: none, low, medium, high, urgent. Defaults to medium.
+    #[serde(default)]
+    pub priority: Option<String>,
+    /// Optional due date, YYYY-MM-DD.
+    #[serde(default)]
+    pub due_date: Option<String>,
+}
+```
+
+- [ ] **Step 2: Tool** — two-phase: resolve project + statuses (→ McpError on miss), pick the status (named or first), parse priority (default medium), parse due_date (`chrono::NaiveDate::parse_from_str(.., "%Y-%m-%d")` → invalid_params on error), then apply `CreateIssue`. Return the new issue's key (re-read by identifier is unnecessary; instead return `{ "created": "<title>" }`, or query the project's issues to find the new id's identifier — simpler to return a success note and let the caller `list_issues`). Concretely return `json_content(&serde_json::json!({"created": args.title}))` after apply. (Resolving the assigned key would require reading back; out of scope — the caller can `list_issues`.)
+
+Show the full handler:
+```rust
+#[tool(description = "Create an issue in a project. status defaults to the first column, priority to medium.")]
+async fn create_issue(
+    &self,
+    Parameters(args): Parameters<crate::inputs::CreateIssueInput>,
+) -> Result<CallToolResult, McpError> {
+    use kanban_core::operation::{CreateIssue, Operation};
+    use kanban_core::types::Priority;
+
+    // phase 1: resolve project + statuses
+    let prefix = args.project.clone();
+    let resolved = self
+        .blocking(move |ws| {
+            let Some(p) = ws.query_project_by_prefix(&prefix)? else { return Ok(None) };
+            let statuses = ws.query_statuses_for_project(p.id)?;
+            Ok(Some((p.id, statuses)))
+        })
+        .await?;
+    let (project_id, statuses) =
+        resolved.ok_or_else(|| crate::error::not_found("project", &args.project))?;
+
+    // status: named or first
+    let status_id = match &args.status {
+        Some(name) => {
+            statuses
+                .iter()
+                .find(|s| &s.name == name)
+                .ok_or_else(|| {
+                    crate::error::unknown_name(
+                        "status",
+                        name,
+                        &args.project,
+                        &statuses.iter().map(|s| s.name.clone()).collect::<Vec<_>>(),
+                    )
+                })?
+                .id
+        }
+        None => statuses.first().map(|s| s.id).ok_or_else(|| {
+            McpError::internal_error("project has no statuses", None)
+        })?,
+    };
+
+    let priority: Priority = match &args.priority {
+        Some(p) => p.parse().map_err(|_| {
+            McpError::invalid_params("priority must be one of none, low, medium, high, urgent", None)
+        })?,
+        None => Priority::Medium,
+    };
+    let due_date = match &args.due_date {
+        Some(d) => Some(chrono::NaiveDate::parse_from_str(d, "%Y-%m-%d").map_err(|_| {
+            McpError::invalid_params("due_date must be YYYY-MM-DD", None)
+        })?),
+        None => None,
+    };
+
+    let title = args.title.clone();
+    self.blocking(move |ws| {
+        ws.apply(Operation::CreateIssue(CreateIssue {
+            id: uuid::Uuid::now_v7(),
+            project_id,
+            title: args.title,
+            description: args.description,
+            status_id,
+            priority,
+            due_date,
+            label_ids: vec![],
+        }))
+        .map(|_| ())
+    })
+    .await?;
+    json_content(&serde_json::json!({ "created": title }))
+}
+```
+
+- [ ] **Step 3: Test** — create_issue in AUTH, then list_issues shows it with the default status; bad priority → invalid_params.
+- [ ] **Step 4: Gates + commit** `feat(mcp): add create_issue tool`
+
+### Task 9: `update_issue`
+
+- [ ] **Step 1: Input** — `key` + optional `title`/`description`/`priority`/`status`/`due_date` (all `#[serde(default)] Option<...>`).
+- [ ] **Step 2: Tool** — resolve the issue by key (→ NotFound) and its project's statuses. For each provided field build an `UpdateIssueField` op with the matching `IssueFieldChange` variant and apply it (multiple ops, one per field):
+  - title → `IssueFieldChange::Title(String)`
+  - description → `IssueFieldChange::Description(Option<String>)` (allow clearing with an explicit empty/`null`)
+  - priority → parse to `Priority`, `IssueFieldChange::Priority(Priority)`
+  - status → resolve name → status_id, `IssueFieldChange::Status(Uuid)`
+  - due_date → parse `NaiveDate`, `IssueFieldChange::DueDate(Option<NaiveDate>)`
+  Apply them in one `blocking` closure (resolve status_id/priority/date BEFORE the closure to keep McpError out). If no fields are provided, return `invalid_params("provide at least one field to update")`.
+- [ ] **Step 3: Test** — update title and priority, then get_issue reflects both; updating an unknown key → NotFound.
+- [ ] **Step 4: Gates + commit** `feat(mcp): add update_issue tool`
+
+### Task 10: `move_issue`
+
+- [ ] **Step 1: Input** — `key`, optional `status` (name), optional `before` (sibling key), optional `after` (sibling key).
+- [ ] **Step 2: Tool** — resolve the issue + project statuses. Determine the target status_id (named, else keep current). If it changes, apply `UpdateIssueField{Status}`. Then compute a new `sort_key` and apply `ReorderIssue`:
+  - Read the target column's issues (`query_issues` filtered to the target status_id), excluding the dragged issue, sorted by `sort_key`.
+  - Find neighbours: if `before`/`after` given, locate that sibling by identifier and take the keys on either side; else append (neighbour-before = last, neighbour-after = none).
+  - `new_sort_key = midpoint(before_key, after_key)` using the same convention as the GUI: both present → average; only-before → before+1024; only-after → after-1024; neither → 1024. Implement a private `fn midpoint(before: Option<f64>, after: Option<f64>) -> f64` in `server.rs`.
+  - Apply `ReorderIssue { id, new_sort_key }`. (Core stores `sort_key` losslessly; you pass the plain `f64` — `ReorderIssue.new_sort_key` is a real `f64` in Rust; the `serde_f64::bits` encoding only matters at the JSON boundary, which does not apply here because we call `apply` in-process with a typed `Operation`.)
+- [ ] **Step 3: Test** — create two issues in AUTH; `move_issue {key:"AUTH-2", before:"AUTH-1"}` then `list_issues` shows AUTH-2 before AUTH-1; `move_issue {key:"AUTH-1", status:"Done"}` then get_issue shows status Done.
+- [ ] **Step 4: Gates + commit** `feat(mcp): add move_issue tool (status change + reorder)`
+
+### Task 11: `undo` + `redo`
+
+- [ ] **Step 1: Tools** (no params)
+```rust
+#[tool(description = "Undo the most recent change.")]
+async fn undo(&self) -> Result<CallToolResult, McpError> {
+    self.blocking(|ws| ws.undo().map(|_| ())).await?;
+    json_content(&serde_json::json!({ "undone": true }))
+}
+
+#[tool(description = "Redo the most recently undone change.")]
+async fn redo(&self) -> Result<CallToolResult, McpError> {
+    self.blocking(|ws| ws.redo().map(|_| ())).await?;
+    json_content(&serde_json::json!({ "redone": true }))
+}
+```
+(`Workspace::undo`/`redo` return `OperationOutcome`; map to `()`. "Nothing to undo" surfaces as `Conflict` → `invalid_request`.)
+
+- [ ] **Step 2: Test** — create_project, undo → list_projects empty, redo → it's back. Undo on empty history → error.
+- [ ] **Step 3: Gates + commit** `feat(mcp): add undo and redo tools`
+
+---
+
+## Phase 5 — Docs + acceptance
+
+### Task 12: Docs — README + DEVELOPMENT + CLAUDE
+
+**Files:** Modify `README.md`, `DEVELOPMENT.md`, `CLAUDE.md`.
+
+- [ ] **Step 1: README** — add a short "Use from an AI assistant (MCP)" section: build with `cargo build -p kanban-mcp --release` (binary at `target/release/kanban-mcp`); it serves over stdio and shares `~/.kanban/data.db`.
+
+- [ ] **Step 2: DEVELOPMENT.md** — add an "MCP server (Spec #3)" section with the registration snippets:
+
+Claude Desktop (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+```json
+{
+  "mcpServers": {
+    "kanban": {
+      "command": "/absolute/path/to/target/release/kanban-mcp",
+      "env": { "KANBAN_DB": "/Users/you/.kanban/data.db" }
+    }
+  }
+}
+```
+Claude Code: `claude mcp add kanban -- /absolute/path/to/target/release/kanban-mcp` (or the equivalent `.mcp.json` entry). Note `KANBAN_DB` is optional (defaults to `~/.kanban/data.db`).
+
+- [ ] **Step 3: CLAUDE.md** — add a short "MCP layer (Spec #3)" note under the Tauri layer section: stdio server in `crates/kanban-mcp` on `rmcp`; shares the workspace DB; reads via `query_*`, writes through `Workspace::apply`; semantic tools resolve prefix/key/status-name to ids; agent orchestration deferred to Spec #4.
+
+- [ ] **Step 4: Commit**
+```bash
+git add README.md DEVELOPMENT.md CLAUDE.md
+git commit -m "docs: document the kanban-mcp server and client registration"
+```
+
+### Task 13: Acceptance gate
+
+- [ ] **Step 1: Full gates**
+```bash
+~/.cargo/bin/cargo fmt --all -- --check
+~/.cargo/bin/cargo clippy --workspace --all-targets -- -D warnings
+~/.cargo/bin/cargo test --workspace
+```
+All green.
+
+- [ ] **Step 2: End-to-end tool sequence test** — add one `#[tokio::test]` in `stdio_smoke.rs` (or a new `tests/e2e_flow.rs`) that drives, over the in-process client, the full loop on a temp DB: `create_project` → `create_issue` → `move_issue` (status change) → `get_issue` (assert new status) → `undo` → `get_issue` (assert reverted). This is the executable form of design acceptance criteria 2–3.
+
+- [ ] **Step 3: Cross-process sanity (manual, documented)** — build the binary, register it with a client per Task 12, ask the assistant to "create a project FOO and an issue in it", then confirm with `target/release/kanban-cli project list` (or `cargo run -p kanban-cli -- project list`) that FOO exists. Record the result in the PR description. (This is manual; not a CI test.)
+
+- [ ] **Step 4: Commit any test additions**
+```bash
+git add crates/kanban-mcp
+git commit -m "test(mcp): add end-to-end create/move/undo flow over stdio"
+```
+
+- [ ] **Step 5:** Use **superpowers:finishing-a-development-branch** to open a PR against `dev`.
+
+---
+
+## Self-review notes
+
+**Spec coverage:** every design section maps to a task — crate/stack (Task 1), core resolution helpers + debt retirement (Task 2), error mapping (Task 3), server skeleton + stdio + integration test (Task 4), read tools (Tasks 5–6), write tools create/update/move/undo/redo (Tasks 7–11), docs/config (Task 12), acceptance incl. the create→move→undo flow and cross-process check (Task 13). Non-goals (delete tools, HTTP, orchestration, resources/prompts, new migration) are not present in any task.
+
+**Identifier handling is consistent:** projects by `prefix`, issues by `key`/`identifier`, statuses/labels by `name`; resolution always via the Task 2 helpers + status lookups, with misses mapped to `not_found`/`unknown_name`.
+
+**`McpError` is kept out of `blocking` closures** (which can only yield `kanban_core::Error`): name/priority/date resolution happens in a first `blocking` (project+statuses) then in plain async code before a second `blocking` that applies the op. Tasks 6, 8, 9, 10 all follow this two-phase shape.
+
+**rmcp version caveat:** all macro/type/import paths target `rmcp` 1.x (1.7 verified). If the resolved version differs, the implementer adjusts imports to the real paths — the names (`tool`/`tool_router`/`tool_handler`/`ToolRouter`/`Parameters`/`CallToolResult`/`Content`/`ServerInfo`/`ServerCapabilities`/`ServiceExt`/`transport::stdio`/`ErrorData`) and the duplex test transport are stable across 1.x.

--- a/docs/superpowers/specs/2026-06-05-kanban-v2-spec-3-mcp-server-design.md
+++ b/docs/superpowers/specs/2026-06-05-kanban-v2-spec-3-mcp-server-design.md
@@ -1,0 +1,127 @@
+# Spec #3 — Kanban MCP Server
+
+**Date:** 2026-06-05
+**Builds on:** [Spec #1 — Core + CLI](2026-05-03-kanban-v2-core-cli-design.md), [Spec #2 — GUI Shell](2026-05-05-kanban-v2-spec-2-gui-shell-design.md)
+**Roadmap epic covered:** E13 MCP
+**Deferred to Spec #4+:** E19 Agents (registry, task contracts, auto-decomposition, validation pipelines, notifications)
+
+## Goals
+
+1. Expose `kanban-core` to MCP clients (Claude Desktop, Claude Code) so an LLM can read and drive a kanban board in natural language.
+2. Present **semantic, well-described tools** the model can use reliably — not a generic "submit Operation JSON" surface.
+3. Preserve every `kanban-core` invariant: sync core, single mutator via `Workspace::apply`, append-only migrations.
+4. Share one workspace across CLI, GUI, and MCP — an issue created in any surface is visible in the others.
+
+## Non-goals
+
+- **Agent orchestration** (E19): agent registry, task contracts, decomposition, validation pipelines, claim/complete lifecycles, notifications. All deferred to Spec #4+. The MCP server is the foundation those will build on.
+- **HTTP / SSE transport.** Local-first; stdio only. Remote transports are a later concern.
+- **Destructive tools.** No `delete_issue` / `delete_project` / `archive` in v1. `undo`/`redo` cover mistake recovery. (Revisit in a later spec if agents need full lifecycle control.)
+- **MCP resources and prompts.** Tools only for v1.
+- **New schema.** Resolution by `prefix`/`identifier` uses existing unique indexes; no migration ships in Spec #3.
+
+## Stack
+
+- **Crate:** new `crates/kanban-mcp` — a `kanban-mcp` binary, added to the Cargo workspace.
+- **SDK:** [`rmcp`](https://crates.io/crates/rmcp) — the official Rust MCP SDK (server side, stdio transport, `#[tool]` macros). Exact version pinned during planning.
+- **Runtime:** `tokio` (multi-thread). The sync core runs inside `tokio::task::spawn_blocking` — the same pattern proven in `kanban-tauri`.
+- **Tests:** `cargo test` (per-tool handler tests on an in-memory `Workspace`; one stdio integration test). Covered by the existing `cargo test --workspace` / clippy / fmt CI gates.
+
+## Architecture
+
+```
+kanban/
+├── crates/
+│   ├── kanban-core/            # +2 indexed resolution helpers (see below)
+│   ├── kanban-cli/             # unchanged
+│   ├── kanban-tauri/           # switches get_issue to the new core helper (retires debt)
+│   └── kanban-mcp/      (new)  # stdio MCP server
+│       ├── src/
+│       │   ├── main.rs         # rmcp stdio server bootstrap
+│       │   ├── server.rs       # KanbanServer: holds Arc<Mutex<Workspace>>, tool impls
+│       │   ├── tools/          # one module per tool group (reads, issues, projects)
+│       │   ├── dto.rs          # serde-friendly tool input/output shapes
+│       │   └── error.rs        # kanban_core::Error -> rmcp tool error mapping
+│       └── Cargo.toml
+```
+
+- `KanbanServer` holds `Arc<Mutex<Workspace>>`, opened via `Workspace::open_default()` — so the server shares `~/.kanban/data.db` (or `$KANBAN_DB`) with the CLI and GUI. SQLite WAL keeps the three multi-process-safe.
+- Every tool clones the `Arc`, and inside `spawn_blocking` locks the mutex and runs the sync core call — the guard never crosses an `.await` (the `kanban-tauri` pattern).
+- **Writes go through `Workspace::apply`.** Each write tool builds the appropriate `Operation` and applies it; the single-mutator invariant is untouched.
+
+### Identifiers
+
+Tools speak the human vocabulary, never UUIDs:
+- Projects are addressed by **prefix** (`AUTH`).
+- Issues are addressed by **key / identifier** (`AUTH-12`).
+- Statuses and labels are referenced **by name** within a project (the server resolves names to ids); ambiguous/unknown names return a clear tool error.
+
+## Tool surface
+
+All tools return structured JSON content. Descriptions and field docs are written for an LLM audience.
+
+### Reads
+| Tool | Input | Returns |
+|------|-------|---------|
+| `list_projects` | — | projects: prefix, name, description |
+| `list_statuses` | `project` (prefix) | the project's status columns, in order |
+| `list_labels` | `project` | labels: name, color |
+| `list_issues` | `project`, optional `status` (name), `priority`, `search` | matching issues (key, title, status, priority, due) |
+| `get_issue` | `key` | full issue incl. description (markdown), labels, timestamps |
+| `search_issues` | `query`, optional `project` | FTS5 results across titles/descriptions |
+
+### Writes (each builds an `Operation` → `Workspace::apply`)
+| Tool | Input | Operation(s) |
+|------|-------|--------------|
+| `create_project` | `name`, `prefix`, optional `description` | `CreateProject` |
+| `create_issue` | `project`, `title`, optional `description`, `status` (name), `priority`, `due_date` | `CreateIssue` (resolves project→id, status name→id, defaults to the project's first status) |
+| `update_issue` | `key`, any of `title`/`description`/`priority`/`status`/`due_date` | one `UpdateIssueField` per changed field |
+| `move_issue` | `key`, optional `status` (name), optional `before`/`after` (sibling key) | `UpdateIssueField{Status}` if the column changes, then `ReorderIssue` with a server-computed midpoint `sort_key` |
+| `undo` | — | `Workspace::undo()` |
+| `redo` | — | `Workspace::redo()` |
+
+`move_issue` computes the new `sort_key` from the neighbours' keys using the same fractional-midpoint convention as the GUI (1024 gap; average between two neighbours). `before`/`after` omitted ⇒ append to the column.
+
+## Core additions (`kanban-core`)
+
+Two indexed resolution helpers on `Workspace` (both columns are already uniquely indexed — `idx_projects_prefix`, `UNIQUE(identifier)` — so **no migration**):
+
+- `query_project_by_prefix(&self, prefix: &str) -> Result<Option<Project>>`
+- `query_issue_by_identifier(&self, identifier: &str) -> Result<Option<Issue>>`
+
+The MCP server uses these for resolution. `kanban-tauri::commands::get_issue_inner` switches to `query_issue_by_identifier`, **retiring the Task 7 full-table-scan FOLLOWUP debt** (it currently scans all issues and filters in Rust).
+
+No new `Operation` variants are needed — the existing 14 cover everything the tools do.
+
+## Error handling
+
+A `kanban_core::Error` → `rmcp` tool-error mapping (mirrors the Spec #2 `ApiError`), producing LLM-actionable messages:
+- `NotFound` → "project AUTH not found" / "issue AUTH-12 not found"
+- `Validation` → the field + reason verbatim ("prefix: must be 2–8 uppercase letters")
+- name-resolution misses (unknown status/label name) → "status 'Doing' not found in project AUTH; available: To Do, In Progress, Done"
+- `Conflict` (e.g. nothing to undo) → the message verbatim
+
+Tool input validation (missing required field, bad enum) is handled by the `rmcp` schema layer before the handler runs.
+
+## Testing (TDD)
+
+- **Per tool:** a test that calls the handler against a fresh `Workspace::open_in_memory()`, asserts the resulting state, and — for writes — asserts `undo` reverses it. Mirrors the core's "every Operation lands as a failing test first" discipline.
+- **Resolution helpers:** unit tests for prefix/identifier hit + miss.
+- **Integration:** one test that drives the server over an in-process stdio pipe — `initialize`, `tools/list` (assert the tool set), and one `tools/call` round-trip — proving transport + schema wiring.
+- **Regression:** the `kanban-tauri` switch to `query_issue_by_identifier` keeps its existing tests green.
+- CI: the new crate is covered by the existing `cargo fmt --check`, `cargo clippy --workspace -D warnings`, `cargo test --workspace` gates. No workflow change required.
+
+## Docs
+
+- `README.md`: a short "Use from an AI assistant (MCP)" section.
+- `DEVELOPMENT.md`: the `mcpServers` config snippet for **Claude Desktop** (`claude_desktop_config.json`) and **Claude Code** (`.mcp.json` / `claude mcp add`), pointing at the built `kanban-mcp` binary, with `KANBAN_DB` override noted.
+- `CLAUDE.md`: a short "MCP layer (Spec #3)" note — stdio server, shares the workspace DB, writes through `apply`, semantic tools, agent orchestration deferred to Spec #4.
+
+## Acceptance criteria
+
+1. `kanban-mcp` builds and starts as a stdio server; `tools/list` returns the full tool set with schemas.
+2. From a fresh DB, an MCP `tools/call` sequence — `create_project` → `create_issue` → `move_issue` → `get_issue` — produces the expected board state, and the same DB is visible from `kanban issue list`.
+3. `undo` reverses the last write; `redo` replays it.
+4. Errors are clear and actionable (unknown project/status/issue).
+5. All workspace gates green (fmt, clippy `-D warnings`, `cargo test --workspace`); the `kanban-tauri` debt retirement keeps its suite green.
+6. Registering the binary per the docs makes the tools usable from Claude Desktop and Claude Code.


### PR DESCRIPTION
## Summary

Implements **Spec #3 — Kanban MCP Server**: a new `crates/kanban-mcp` stdio MCP server (built on `rmcp` 1.7) that exposes `kanban-core` to AI assistants (Claude Desktop, Claude Code). Built test-first across 13 plan tasks.

**Tools (12, semantic — each write goes through `Workspace::apply`):**
- Reads: `list_projects`, `list_statuses`, `list_labels`, `list_issues` (filter by status/priority/search), `get_issue`, `search_issues`.
- Writes: `create_project`, `create_issue`, `update_issue`, `move_issue` (status change + fractional sort-key reorder), `undo`, `redo`.

**Design highlights**
- Shares `~/.kanban/data.db` with the CLI and GUI (`Workspace::open_default`; SQLite WAL multi-process-safe). Each async tool runs the sync core inside `tokio::task::spawn_blocking` over an `Arc<Mutex<Workspace>>` — the guard never crosses `.await`.
- Tools speak human identifiers — project `prefix`, issue `key`, status/label `name` — resolved to core UUIDs; misses map to `not_found`/`unknown_name` MCP errors. Output DTOs are human-facing (no UUIDs/sort_keys).
- **`kanban-core`**: two indexed resolution helpers (`query_project_by_prefix`, `query_issue_by_identifier`); no new migration (existing unique indexes). The `kanban-tauri` `get_issue` full-table-scan debt is retired to use them.

**Deferred to Spec #4+:** agent orchestration (registry, task contracts, decomposition, validation pipelines). HTTP/SSE transport and destructive delete tools are also out of scope.

## Test plan
- [x] `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` (37 result blocks, 0 failures)
- [x] Per-tool tests + an end-to-end create→move→update→undo→redo flow, driven over a real in-process `tokio::io::duplex` MCP transport
- [x] `cargo build -p kanban-mcp` (binary builds); `rmcp` resolves to 1.7.0
- [ ] Manual cross-process check: build `kanban-mcp`, register per `DEVELOPMENT.md`, ask the assistant to create a project + issue, confirm with `kanban project list`