### PR TITLE
v2: Spec #4 — GUI Product Completeness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,8 @@ The GUI is `crates/kanban-tauri` (Rust shell) + `ui/` (Vite + React 19 + Tailwin
 - **`tauri-specta` generates `ui/src/data/bindings.ts`** (git-tracked) via the `export_bindings` test; CI fails on drift. `specta-typescript` is configured with `BigIntExportBehavior::Number` so `i64` fields become TS `number`.
 - **No live cross-process watcher.** The GUI refetches on window focus (`refetchOnWindowFocus`); a SQLite `update_hook` watcher is deferred to a later spec.
 - **E2E (`tauri-driver`) is deferred to a later spec** (no macOS WebDriver support); Spec #2 ships Vitest + RTL coverage. See `ui/e2e/README.md`.
-- **UI tooling on Apple Silicon:** if the default `node` is x86_64 (nvm), run ui scripts under a native arm64 node (`PATH="/opt/homebrew/bin:$PATH" npx pnpm@9.12.0 …`) or rollup/esbuild crash. See `DEVELOPMENT.md`.
+- **UI tooling on Apple Silicon:** if the default `node` is x86_64 (nvm), run ui scripts under a native arm64 node (`PATH="/opt/homebrew/bin:$PATH" npx pnpm@9.12.0 …`) or rollup/esbuild crash. If `node_modules` ends up with the wrong-arch rollup binary (a plain `install` reports "up to date" but `build` fails on `@rollup/rollup-darwin-arm64`), repair with `… pnpm@9.12.0 install --force`. `test:unit` can pass while `build` fails, so always run `build`. See `DEVELOPMENT.md`.
+- **GUI product completeness (Spec #4).** Issue detail-panel editing of priority, due date, and labels (chips + attach/detach/create), issue delete, ⌘Z/⌘⇧Z undo-redo (wrapping `commands.undo`/`redo` + broad query invalidation), and project rename/archive/delete from the sidebar — all via `ops.ts` builders through `apply`. The one core addition is `Workspace::query_labels_for_issue`, surfaced by `get_issue` as `IssueDto.labels: Option<Vec<LabelDto>>` (None for `list_issues`). Custom statuses (no status `Operation`) and members/assignee (not in schema) remain deferred to Spec #5+.
 
 ## MCP layer (Spec #3)
 
@@ -92,5 +93,6 @@ These don't block v1 but should be addressed before broader release:
 - `docs/superpowers/plans/2026-05-03-kanban-v2-core-cli-plan.md` — the 41-task TDD plan that built it.
 - `docs/superpowers/specs/2026-05-05-kanban-v2-spec-2-gui-shell-design.md` — Spec #2 (Tauri GUI shell).
 - `docs/superpowers/specs/2026-06-05-kanban-v2-spec-3-mcp-server-design.md` — Spec #3 (MCP server).
+- `docs/superpowers/specs/2026-06-06-kanban-v2-spec-4-gui-product-completeness-design.md` — Spec #4 (GUI product completeness).
 
-Each spec has a matching plan in `docs/superpowers/plans/`. AI-agent orchestration (Spec #4+) will live alongside.
+Each spec has a matching plan in `docs/superpowers/plans/`. Custom statuses, members/assignee, and AI-agent orchestration (Spec #5+) will live alongside.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ By default the workspace lives at `~/.kanban/data.db`. Override with `KANBAN_DB=
 
 A macOS desktop GUI (Tauri + React) ships alongside the CLI, built on the same
 `kanban-core` library: a drag-and-drop kanban board, a markdown issue detail
-panel, project sidebar, and light/dark/system theming.
+panel with priority / due-date / label editing and delete, a project sidebar
+with rename / archive / delete, ⌘Z / ⌘⇧Z undo-redo, and light/dark/system
+theming.
 
 Download the latest macOS DMG from
 [GitHub Releases](https://github.com/akassharjun/kanban/releases). The first

--- a/crates/kanban-core/src/store/read/labels.rs
+++ b/crates/kanban-core/src/store/read/labels.rs
@@ -16,6 +16,20 @@ pub(crate) fn for_project(conn: &Connection, project_id: Uuid) -> Result<Vec<Lab
     Ok(out)
 }
 
+pub(crate) fn for_issue(conn: &Connection, issue_id: Uuid) -> Result<Vec<Label>> {
+    let mut stmt = conn.prepare(
+        "SELECT l.id, l.project_id, l.name, l.color \
+         FROM labels l JOIN issue_labels il ON il.label_id = l.id \
+         WHERE il.issue_id = ?1 ORDER BY l.name",
+    )?;
+    let rows = stmt.query_map(params![issue_id.to_string()], row_to_label)?;
+    let mut out = Vec::new();
+    for r in rows {
+        out.push(r?);
+    }
+    Ok(out)
+}
+
 pub(crate) fn for_project_via_tx(
     tx: &rusqlite::Transaction<'_>,
     project_id: Uuid,

--- a/crates/kanban-core/src/workspace.rs
+++ b/crates/kanban-core/src/workspace.rs
@@ -117,6 +117,18 @@ impl Workspace {
         crate::store::read::labels::for_project(&self.conn, project_id)
     }
 
+    /// List all labels attached to `issue_id` ordered by name.
+    ///
+    /// # Errors
+    ///
+    /// Returns a database error if the read fails.
+    pub fn query_labels_for_issue(
+        &self,
+        issue_id: uuid::Uuid,
+    ) -> crate::error::Result<Vec<crate::types::Label>> {
+        crate::store::read::labels::for_issue(&self.conn, issue_id)
+    }
+
     /// Look up an issue by id.
     ///
     /// # Errors

--- a/crates/kanban-core/tests/labels_for_issue.rs
+++ b/crates/kanban-core/tests/labels_for_issue.rs
@@ -1,0 +1,71 @@
+#![allow(clippy::unwrap_used)]
+use kanban_core::Workspace;
+use kanban_core::operation::{AttachLabel, CreateIssue, CreateLabel, CreateProject, Operation};
+use kanban_core::types::Priority;
+use uuid::Uuid;
+
+#[test]
+fn labels_for_issue_returns_attached_sorted_and_empty_when_none() {
+    let mut ws = Workspace::open_in_memory().unwrap();
+
+    let pid = Uuid::now_v7();
+    ws.apply(Operation::CreateProject(CreateProject {
+        id: pid,
+        name: "Auth".into(),
+        prefix: "AUTH".into(),
+        description: None,
+        icon: None,
+    }))
+    .unwrap();
+    let status_id = ws.query_statuses_for_project(pid).unwrap()[0].id;
+
+    let iid = Uuid::now_v7();
+    ws.apply(Operation::CreateIssue(CreateIssue {
+        id: iid,
+        project_id: pid,
+        title: "Add OAuth".into(),
+        description: None,
+        status_id,
+        priority: Priority::Medium,
+        due_date: None,
+        label_ids: vec![],
+    }))
+    .unwrap();
+
+    // Issue with no labels returns an empty vec.
+    assert!(ws.query_labels_for_issue(iid).unwrap().is_empty());
+
+    let label_b = Uuid::now_v7();
+    ws.apply(Operation::CreateLabel(CreateLabel {
+        id: label_b,
+        project_id: pid,
+        name: "bug".into(),
+        color: "#ff0000".into(),
+    }))
+    .unwrap();
+    let label_a = Uuid::now_v7();
+    ws.apply(Operation::CreateLabel(CreateLabel {
+        id: label_a,
+        project_id: pid,
+        name: "api".into(),
+        color: "#00ff00".into(),
+    }))
+    .unwrap();
+
+    ws.apply(Operation::AttachLabel(AttachLabel {
+        issue_id: iid,
+        label_id: label_b,
+    }))
+    .unwrap();
+    ws.apply(Operation::AttachLabel(AttachLabel {
+        issue_id: iid,
+        label_id: label_a,
+    }))
+    .unwrap();
+
+    let labels = ws.query_labels_for_issue(iid).unwrap();
+    assert_eq!(labels.len(), 2);
+    // Ordered by name.
+    let names: Vec<&str> = labels.iter().map(|l| l.name.as_str()).collect();
+    assert_eq!(names, vec!["api", "bug"]);
+}

--- a/crates/kanban-tauri/src/commands.rs
+++ b/crates/kanban-tauri/src/commands.rs
@@ -81,7 +81,12 @@ pub fn list_issues_inner(ws: &Workspace, prefix: &str) -> Result<Vec<IssueDto>, 
 /// error if the underlying query fails.
 pub fn get_issue_inner(ws: &Workspace, key: &str) -> Result<IssueDto, ApiError> {
     match ws.query_issue_by_identifier(key)? {
-        Some(issue) => Ok(IssueDto::from(issue)),
+        Some(issue) => {
+            let labels = ws.query_labels_for_issue(issue.id)?;
+            let mut dto = IssueDto::from(issue);
+            dto.labels = Some(labels.into_iter().map(LabelDto::from).collect());
+            Ok(dto)
+        }
         None => Err(ApiError::NotFound {
             resource: "issue".into(),
             key: key.into(),

--- a/crates/kanban-tauri/src/dto.rs
+++ b/crates/kanban-tauri/src/dto.rs
@@ -73,6 +73,7 @@ pub struct IssueDto {
     pub sort_key: f64,
     pub created_at: String,
     pub updated_at: String,
+    pub labels: Option<Vec<LabelDto>>,
 }
 
 impl From<Issue> for IssueDto {
@@ -90,6 +91,7 @@ impl From<Issue> for IssueDto {
             sort_key: i.sort_key,
             created_at: i.created_at.to_rfc3339(),
             updated_at: i.updated_at.to_rfc3339(),
+            labels: None,
         }
     }
 }

--- a/docs/superpowers/plans/2026-06-06-kanban-v2-spec-4-gui-product-completeness-plan.md
+++ b/docs/superpowers/plans/2026-06-06-kanban-v2-spec-4-gui-product-completeness-plan.md
@@ -1,0 +1,105 @@
+# Kanban v2 — Spec #4 GUI Product Completeness Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Close the daily-driver gaps in the desktop GUI — issue priority/due-date editing, delete, labels, undo/redo (⌘Z), and project rename/archive/delete — all on top of the existing `kanban-core` operations.
+
+**Architecture:** Frontend-first. Writes go through the existing `useApply` → `apply(Operation)`. New operations are `ops.ts` builders only (no new Tauri write commands). One small core read (`query_labels_for_issue`) + a `get_issue` DTO `labels` field (regenerates the git-tracked `bindings.ts`). Undo/redo wrap the existing `commands.undo`/`redo`.
+
+**Tech Stack:** React 19 / Vite / Tailwind v4 / TanStack Query (Spec #2 stack). Rust 2024 / rusqlite (core). Tests: Vitest + RTL (test-first), `cargo test` for the core helper.
+
+**Spec:** `docs/superpowers/specs/2026-06-06-kanban-v2-spec-4-gui-product-completeness-design.md`
+
+## Conventions (every task)
+- UI commands run under the arm64 node: `cd ui && PATH="/opt/homebrew/bin:$PATH" npx --yes pnpm@9.12.0 <script>` (test:unit / typecheck / lint / build).
+- Rust via `~/.cargo/bin/cargo`. Gates: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`; ui `typecheck`/`lint`/`test:unit`/`build`. CONFIRM each gate exits 0 explicitly (don't trust a tail).
+- ESLint: `@typescript-eslint/no-explicit-any` is an ERROR — no `as any` anywhere; unused vars prefixed `_`. Use `vi.hoisted` for any mock referenced in a hoisted `vi.mock` factory.
+- No `Co-Authored-By` / AI attribution in commits. Conventional-commit prefixes.
+
+---
+
+### Task 1: Operation builders for labels + projects (`ops.ts`) — test-first
+
+**Files:** `ui/src/data/ops.ts`, `ui/tests/data/ops.test.ts`
+
+Add builders producing the exact `{op, args}` serde shapes (verify against `crates/kanban-core/src/operation.rs`): `createLabel({id, project_id, name, color})`, `updateLabel({id, name?, color?})`, `deleteLabel({id})`, `attachLabel({issue_id, label_id})`, `detachLabel({issue_id, label_id})`, `updateProject({id, ...})`, `archiveProject({id})`, `deleteProject({id})`. (`deleteIssue` already exists.) Verify each struct's fields against core (e.g. `CreateLabel{id,project_id,name,color}`, `AttachLabel{issue_id,label_id}`, `ArchiveProject`/`DeleteProject` — confirm whether they take `{id}` only). Test the produced shapes.
+
+- [ ] Write failing `ops.test.ts` cases for the new builders (assert `{op, args}`).
+- [ ] Implement the builders.
+- [ ] `test:unit -- ops`, typecheck, lint green. Commit `feat(ui): add label and project operation builders`.
+
+### Task 2: Priority editor in the detail panel
+
+**Files:** `ui/src/components/detail/IssuePanel.tsx` (+ a small `PrioritySelect` component if cleaner), test.
+
+Add a priority control to `IssuePanel` (segmented buttons or a `<select>`, values none/low/medium/high/urgent) bound to the issue's current priority; on change → `apply.mutate(ops.updateIssueField({ id, change: change.priority(value) }))`. Test (RTL): rendering with a mocked `useIssue`/`useApply`, changing priority dispatches `UpdateIssueField` with `change == {field:"Priority", value:<v>}`.
+
+- [ ] Test-first; implement; gates green. Commit `feat(ui): edit issue priority in the detail panel`.
+
+### Task 3: Due-date editor in the detail panel
+
+**Files:** `IssuePanel.tsx`, test.
+
+Add a date `<input type="date">` (value = issue.due_date or empty; clearable) → `apply.mutate(ops.updateIssueField({ id, change: change.dueDate(value || null) }))`. Test: setting a date dispatches `{field:"DueDate", value:"YYYY-MM-DD"}`; clearing dispatches `value:null`.
+
+- [ ] Test-first; implement; gates green. Commit `feat(ui): edit issue due date in the detail panel`.
+
+### Task 4: Delete-issue action in the detail panel
+
+**Files:** `IssuePanel.tsx`, test.
+
+Add a destructive "Delete issue" button (with an inline confirm) → `apply.mutate(ops.deleteIssue({ id }))`, then `navigate(\`/p/${prefix}\`)` to close the panel/return to the board. Test: confirm → dispatches `DeleteIssue` + navigates.
+
+- [ ] Test-first; implement; gates green. Commit `feat(ui): delete an issue from the detail panel`.
+
+### Task 5: Undo/redo hooks + ⌘Z / ⌘⇧Z
+
+**Files:** `ui/src/data/mutations.ts` (or `queries.ts`), `ui/src/routes/_layout.tsx` (or a small `useKeyboardUndo` hook), tests.
+
+- `useUndo()` / `useRedo()` — `useMutation` calling `commands.undo()` / `commands.redo()` (unwrap the Result), `onSettled: () => qc.invalidateQueries()` (broad). A "nothing to undo" error is swallowed/toasted, not thrown to the UI.
+- A global keyboard handler (mounted once, e.g. in `_layout.tsx` via `useEffect` on `window` keydown): `⌘Z` (metaKey+z, no shift) → undo; `⌘⇧Z` → redo. Show a brief toast/status line.
+- Tests: the hooks call the right command + invalidate; the key handler maps the right combos (can unit-test the handler logic).
+
+- [ ] Test-first; implement; gates green. Commit `feat(ui): wire ⌘Z / ⌘⇧Z undo and redo`.
+
+### Task 6: Core `query_labels_for_issue` + `get_issue` labels + regen bindings
+
+**Files:** `crates/kanban-core/src/workspace.rs` (+ `store/read/labels.rs`), `crates/kanban-core/tests/`, `crates/kanban-tauri/src/{commands.rs,dto.rs}`, regenerate `ui/src/data/bindings.ts`.
+
+- Core (test-first): `Workspace::query_labels_for_issue(&self, issue_id: Uuid) -> Result<Vec<Label>>` — `SELECT label_id FROM issue_labels WHERE issue_id=?` joined to labels (or reuse `labels::for_project` + filter). Unit test: attach two labels, assert both returned.
+- Tauri: a `LabelDto` already exists; make `get_issue` return an `IssueDetailDto { #[serde(flatten)] issue: IssueDto, labels: Vec<LabelDto> }` (or add a `labels: Vec<LabelDto>` field to a detail struct) by calling `query_labels_for_issue` in `get_issue_inner`. Keep `list_issues` returning plain `IssueDto` (no per-issue label load for the board in this spec).
+- Regenerate bindings: `cargo test -p kanban-tauri --test export_bindings` (or the binary's debug export); commit the updated `ui/src/data/bindings.ts`.
+
+- [ ] Test-first core helper; wire the DTO; regen bindings; `cargo test --workspace` + ui typecheck green (bindings drift guard clean). Commit `feat(core): expose an issue's labels via get_issue`.
+
+### Task 7: Label display + attach/detach + create in the detail panel
+
+**Files:** `IssuePanel.tsx` (+ a `LabelPicker` component), `ui/src/data/queries.ts` (a `useLabels(prefix)` hook already exists — reuse), tests.
+
+- Show the issue's labels (from the `get_issue` detail) as colored chips.
+- A label picker: lists the project's labels (`useLabels`), each toggling attach/detach via `ops.attachLabel`/`ops.detachLabel` (using `issue.id` + `label.id`); on toggle, `apply.mutate` and invalidate the issue.
+- A "+ New label" affordance (name + a color) → `ops.createLabel({ id: uuidv7(), project_id, name, color })`, then it appears in the picker.
+- Test: rendering shows existing chips; toggling a label dispatches attach/detach with the right ids; creating dispatches `CreateLabel`.
+
+- [ ] Test-first; implement; gates green. Commit `feat(ui): label chips, attach/detach, and create in the detail panel`.
+
+### Task 8: Project rename / archive / delete from the sidebar
+
+**Files:** `ui/src/components/sidebar/ProjectList.tsx` (+ a `ProjectMenu`/`ProjectSettingsDialog`), tests.
+
+- Per-project affordance (hover menu or a settings dialog) to: **rename** (`ops.updateProject({ id, name })`), **archive** (`ops.archiveProject({ id })`), **delete** (`ops.deleteProject({ id })`, with confirm). Verify `UpdateProject`/`ArchiveProject`/`DeleteProject` arg shapes against core.
+- After delete/archive of the active project, navigate to `/`.
+- Test: rename dispatches `UpdateProject`; delete (confirmed) dispatches `DeleteProject` and navigates.
+
+- [ ] Test-first; implement; gates green. Commit `feat(ui): rename, archive, and delete projects from the sidebar`.
+
+### Task 9: Acceptance + docs
+
+- [ ] Full gates: `cargo fmt/clippy/test --workspace`; ui `typecheck`/`lint`/`test:unit`/`build`; bindings drift clean.
+- [ ] Update README/CLAUDE feature lists to reflect the now-complete GUI (labels, priority/due editing, delete, undo shortcut, project management). Note custom statuses / members deferred to a later spec.
+- [ ] Commit, then superpowers:finishing-a-development-branch → PR to `dev`.
+
+## Self-review notes
+- Every write reuses `useApply` → `apply` → `Workspace::apply` (single-mutator invariant). Only `ops.ts` gains builders; only `get_issue` gains a `labels` field (one bindings regen). No new migration.
+- Deferred (need new core ops/schema): custom statuses, members/assignee, hierarchy, multi-views — flagged for Spec #5+.
+- Verify each op's arg struct against `operation.rs` before building its `ops.ts` builder (don't assume field sets).

--- a/docs/superpowers/specs/2026-06-06-kanban-v2-spec-4-gui-product-completeness-design.md
+++ b/docs/superpowers/specs/2026-06-06-kanban-v2-spec-4-gui-product-completeness-design.md
@@ -1,0 +1,52 @@
+# Spec #4 — GUI Product Completeness
+
+**Date:** 2026-06-06
+**Builds on:** Spec #1 (core + CLI), Spec #2 (GUI shell), Spec #3 (MCP server)
+**Roadmap epics covered:** E08 Labels (GUI) · E16 Shortcuts (⌘Z/⌘⇧Z undo/redo) · E17 Undo/Redo wired to the GUI · issue priority/due-date editing · issue delete · E02 Projects (rename/archive/delete)
+**Deferred to Spec #5+ (need new core ops / schema):** E11 Custom Statuses (no `CreateStatus`/`UpdateStatus`/`DeleteStatus` operation exists) · E03 Members/Assignee (not in schema) · E07 Hierarchy · E09 Multi-views · E19 Agent orchestration
+
+## Goal
+
+Close the remaining gaps that keep the desktop GUI from being a complete daily-driver. Every feature here is **already supported by `kanban-core`** — the 14 `Operation` variants cover labels, deletes, and project edits, and the generic `apply` command dispatches any of them. The only backend change is one small read helper for an issue's labels.
+
+## Non-goals
+
+- Custom status columns, members/assignee, hierarchy, multi-views, templates, import/export UI, notifications, audit UI, agent orchestration — all need new core operations or schema and are out of scope.
+- No new migration. No new specta-typed command except the `get_issue` DTO gaining a `labels` field (regenerates `bindings.ts`).
+
+## Architecture notes
+
+- Writes still go through the GUI's `useApply` (→ `apply(Operation)` → `Workspace::apply`). New operations are added as `ops.ts` builders only — no new Tauri commands.
+- Undo/redo use the existing `commands.undo`/`commands.redo` bindings, wrapped in mutation hooks that invalidate all queries.
+- Showing an issue's labels needs core read support: add `Workspace::query_labels_for_issue(issue_id)`, surface it on the detail read (`get_issue` → a richer `IssueDetailDto { ...IssueDto, labels: LabelDto[] }`), and regenerate `bindings.ts` (git-tracked, drift-guarded by CI).
+
+## Features
+
+### 1. Operation builders (`ops.ts`)
+Add builders for the ops the GUI now needs (each produces the `{op, args}` shape; `apply` deserializes): `createLabel`, `updateLabel`, `deleteLabel`, `attachLabel`, `detachLabel`, `updateProject`, `archiveProject`, `deleteProject`. (`deleteIssue` already exists.) Test the wire shapes against the core structs (`CreateLabel{id,project_id,name,color}`, `AttachLabel{issue_id,label_id}`, etc.).
+
+### 2. Detail-panel field editors
+In `IssuePanel`:
+- **Priority** — a small segmented control / select (none/low/medium/high/urgent) → `updateIssueField(change.priority)`.
+- **Due date** — a date input (YYYY-MM-DD, clearable) → `updateIssueField(change.dueDate)`.
+- **Delete issue** — a destructive action (with confirm) → `apply(deleteIssue)` then navigate back to the board. (Recoverable via undo.)
+
+### 3. Undo / redo
+- `useUndo`/`useRedo` mutation hooks (call `commands.undo`/`redo`, then `queryClient.invalidateQueries()` broadly).
+- A global `⌘Z` / `⌘⇧Z` keyboard handler (mounted in the layout) that fires undo/redo and shows a brief toast/status (e.g. "Undone" / "Nothing to undo").
+
+### 4. Labels
+- **Core:** `Workspace::query_labels_for_issue(issue_id) -> Vec<Label>` (test-first; joins `issue_labels`).
+- **Bridge:** `get_issue` returns `IssueDetailDto` = the issue fields + `labels: LabelDto[]`. Regenerate `bindings.ts`.
+- **GUI:** label chips on the detail panel; a label picker that lists the project's labels and toggles attach/detach (`attachLabel`/`detachLabel`); a "new label" affordance (name + color) → `createLabel`. Board cards showing label chips is a stretch (needs `list_issues` to carry labels); deferred unless cheap.
+
+### 5. Project management
+- Sidebar affordance (context menu or a small project-settings view) to **rename** (`updateProject`), **archive** (`archiveProject`), and **delete** (`deleteProject`, with confirm) a project; deleting/archiving navigates away if the active project is affected.
+
+## Testing
+
+Vitest + RTL for every component (test-first where the plan says so); `ops.ts` wire-shape tests; one core unit test for `query_labels_for_issue`; the `bindings.ts` drift guard stays green. All existing gates (`cargo` fmt/clippy/test, `pnpm` typecheck/lint/test/build) stay green. The arm64-node invocation (`PATH="/opt/homebrew/bin:$PATH" npx pnpm@9.12.0 …`) applies to all UI commands.
+
+## Acceptance
+
+The desktop app can: set an issue's priority and due date; delete an issue (and ⌘Z it back); create, attach, and detach labels on an issue; rename / archive / delete a project — all persisted to the shared workspace and reflected after refresh.

--- a/ui/src/components/detail/IssuePanel.tsx
+++ b/ui/src/components/detail/IssuePanel.tsx
@@ -5,6 +5,7 @@ import { useApply } from "@/data/mutations";
 import { ops, change, PRIORITIES, type Priority } from "@/data/ops";
 import { EditableField } from "./EditableField";
 import { EditableDescription } from "./EditableDescription";
+import { LabelPicker } from "./LabelPicker";
 
 export function IssuePanel() {
   const { prefix = "", key = "" } = useParams();
@@ -25,6 +26,7 @@ export function IssuePanel() {
   if (!issue) return null;
 
   const close = () => navigate(`/p/${prefix}`);
+  const labels = issue.labels ?? [];
 
   return (
     <>
@@ -99,6 +101,39 @@ export function IssuePanel() {
               className="rounded border border-black/15 bg-transparent px-1.5 py-0.5 text-xs dark:border-white/15"
             />
           </label>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-1.5 border-b border-black/10 px-5 py-2.5 text-xs dark:border-white/10">
+          {labels.map((l) => (
+            <span
+              key={l.id}
+              className="inline-flex items-center gap-1 rounded-full border border-black/10 px-2 py-0.5 dark:border-white/10"
+              style={{ backgroundColor: `${l.color}22` }}
+            >
+              <span
+                aria-hidden
+                className="h-2 w-2 rounded-full"
+                style={{ backgroundColor: l.color }}
+              />
+              <span>{l.name}</span>
+              <button
+                type="button"
+                aria-label={`Remove ${l.name}`}
+                onClick={() =>
+                  apply.mutate(ops.detachLabel({ issue_id: issue.id, label_id: l.id }))
+                }
+                className="text-neutral-500 hover:text-neutral-900 dark:hover:text-white"
+              >
+                ×
+              </button>
+            </span>
+          ))}
+          <LabelPicker
+            prefix={prefix}
+            issueId={issue.id}
+            projectId={issue.project_id}
+            attached={labels}
+          />
         </div>
 
         <section className="px-5 pt-4">

--- a/ui/src/components/detail/IssuePanel.tsx
+++ b/ui/src/components/detail/IssuePanel.tsx
@@ -2,12 +2,9 @@ import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import { useIssue, useStatuses } from "@/data/queries";
 import { useApply } from "@/data/mutations";
-import { ops, change } from "@/data/ops";
+import { ops, change, PRIORITIES, type Priority } from "@/data/ops";
 import { EditableField } from "./EditableField";
 import { EditableDescription } from "./EditableDescription";
-
-const PRIORITIES = ["none", "low", "medium", "high", "urgent"] as const;
-type Priority = (typeof PRIORITIES)[number];
 
 export function IssuePanel() {
   const { prefix = "", key = "" } = useParams();

--- a/ui/src/components/detail/IssuePanel.tsx
+++ b/ui/src/components/detail/IssuePanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import { useIssue, useStatuses } from "@/data/queries";
 import { useApply } from "@/data/mutations";
@@ -6,12 +6,16 @@ import { ops, change } from "@/data/ops";
 import { EditableField } from "./EditableField";
 import { EditableDescription } from "./EditableDescription";
 
+const PRIORITIES = ["none", "low", "medium", "high", "urgent"] as const;
+type Priority = (typeof PRIORITIES)[number];
+
 export function IssuePanel() {
   const { prefix = "", key = "" } = useParams();
   const navigate = useNavigate();
   const { data: issue } = useIssue(key);
   const { data: statuses = [] } = useStatuses(prefix);
   const apply = useApply(prefix);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -33,6 +37,7 @@ export function IssuePanel() {
           <div className="flex items-center gap-3">
             <span className="font-mono text-xs text-neutral-500">{issue.identifier}</span>
             <select
+              aria-label="Status"
               value={issue.status_id}
               onChange={(e) =>
                 apply.mutate(
@@ -57,6 +62,48 @@ export function IssuePanel() {
           </button>
         </header>
 
+        <div className="flex items-center gap-4 border-b border-black/10 px-5 py-2.5 text-xs dark:border-white/10">
+          <label className="flex items-center gap-2 text-neutral-500">
+            <span>Priority</span>
+            <select
+              aria-label="Priority"
+              value={issue.priority}
+              onChange={(e) =>
+                apply.mutate(
+                  ops.updateIssueField({
+                    id: issue.id,
+                    change: change.priority(e.target.value as Priority),
+                  }),
+                )
+              }
+              className="rounded border border-black/15 bg-transparent px-1.5 py-0.5 text-xs capitalize dark:border-white/15"
+            >
+              {PRIORITIES.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex items-center gap-2 text-neutral-500">
+            <span>Due date</span>
+            <input
+              type="date"
+              aria-label="Due date"
+              value={issue.due_date ?? ""}
+              onChange={(e) =>
+                apply.mutate(
+                  ops.updateIssueField({
+                    id: issue.id,
+                    change: change.dueDate(e.target.value || null),
+                  }),
+                )
+              }
+              className="rounded border border-black/15 bg-transparent px-1.5 py-0.5 text-xs dark:border-white/15"
+            />
+          </label>
+        </div>
+
         <section className="px-5 pt-4">
           <EditableField
             value={issue.title}
@@ -74,6 +121,38 @@ export function IssuePanel() {
             }
           />
         </section>
+
+        <footer className="flex items-center justify-end gap-2 border-t border-black/10 px-5 py-3 dark:border-white/10">
+          {confirmingDelete ? (
+            <>
+              <button
+                type="button"
+                onClick={() => setConfirmingDelete(false)}
+                className="rounded-md border border-black/15 px-2.5 py-1 text-xs hover:bg-black/5 dark:border-white/15 dark:hover:bg-white/10"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  apply.mutate(ops.deleteIssue({ id: issue.id }));
+                  navigate(`/p/${prefix}`);
+                }}
+                className="rounded-md bg-red-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-red-700"
+              >
+                Confirm
+              </button>
+            </>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setConfirmingDelete(true)}
+              className="rounded-md border border-red-500/40 px-2.5 py-1 text-xs font-medium text-red-600 hover:bg-red-500/10 dark:text-red-400"
+            >
+              Delete
+            </button>
+          )}
+        </footer>
       </aside>
     </>
   );

--- a/ui/src/components/detail/LabelPicker.tsx
+++ b/ui/src/components/detail/LabelPicker.tsx
@@ -1,0 +1,113 @@
+import { useState } from "react";
+import { useLabels } from "@/data/queries";
+import { useApply } from "@/data/mutations";
+import { ops } from "@/data/ops";
+import { uuidv7 } from "@/lib/uuid";
+import type { LabelDto } from "@/data/bindings";
+
+const DEFAULT_COLOR = "#64748b";
+
+export function LabelPicker({
+  prefix,
+  issueId,
+  projectId,
+  attached,
+}: {
+  prefix: string;
+  issueId: string;
+  projectId: string;
+  attached: LabelDto[];
+}) {
+  const { data: labels = [] } = useLabels(prefix);
+  const apply = useApply(prefix);
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [color, setColor] = useState(DEFAULT_COLOR);
+
+  const attachedIds = new Set(attached.map((l) => l.id));
+
+  const toggle = (label: LabelDto) => {
+    if (attachedIds.has(label.id)) {
+      apply.mutate(ops.detachLabel({ issue_id: issueId, label_id: label.id }));
+    } else {
+      apply.mutate(ops.attachLabel({ issue_id: issueId, label_id: label.id }));
+    }
+  };
+
+  const add = () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    apply.mutate(ops.createLabel({ id: uuidv7(), project_id: projectId, name: trimmed, color }));
+    setName("");
+    setColor(DEFAULT_COLOR);
+  };
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="rounded border border-black/15 px-1.5 py-0.5 text-xs text-neutral-500 hover:bg-black/5 dark:border-white/15 dark:hover:bg-white/10"
+      >
+        + Labels
+      </button>
+
+      {open && (
+        <div className="absolute left-0 z-50 mt-1 w-56 rounded-md border border-black/10 bg-white p-1.5 shadow-lg dark:border-white/10 dark:bg-neutral-900">
+          <ul className="max-h-48 overflow-y-auto">
+            {labels.map((l: LabelDto) => {
+              const on = attachedIds.has(l.id);
+              return (
+                <li key={l.id}>
+                  <button
+                    type="button"
+                    onClick={() => toggle(l)}
+                    aria-pressed={on}
+                    className="flex w-full items-center gap-2 rounded px-1.5 py-1 text-left text-xs hover:bg-black/5 dark:hover:bg-white/10"
+                  >
+                    <span
+                      aria-hidden
+                      className="h-2.5 w-2.5 shrink-0 rounded-full border border-black/10"
+                      style={{ backgroundColor: l.color }}
+                    />
+                    <span className="flex-1">{l.name}</span>
+                    {on && <span aria-hidden>✓</span>}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+
+          <div className="mt-1 flex items-center gap-1.5 border-t border-black/10 pt-1.5 dark:border-white/10">
+            <input
+              type="color"
+              aria-label="New label color"
+              value={color}
+              onChange={(e) => setColor(e.target.value)}
+              className="h-6 w-6 shrink-0 cursor-pointer rounded border border-black/15 bg-transparent dark:border-white/15"
+            />
+            <input
+              type="text"
+              aria-label="New label name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") add();
+              }}
+              placeholder="New label"
+              className="min-w-0 flex-1 rounded border border-black/15 bg-transparent px-1.5 py-0.5 text-xs dark:border-white/15"
+            />
+            <button
+              type="button"
+              onClick={add}
+              className="rounded border border-black/15 px-1.5 py-0.5 text-xs hover:bg-black/5 dark:border-white/15 dark:hover:bg-white/10"
+            >
+              Add
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/sidebar/ProjectList.tsx
+++ b/ui/src/components/sidebar/ProjectList.tsx
@@ -1,5 +1,5 @@
-import { NavLink } from "react-router";
 import { useProjects } from "@/data/queries";
+import { ProjectRow } from "./ProjectRow";
 
 export function ProjectList() {
   const { data, isLoading, isError } = useProjects();
@@ -10,20 +10,7 @@ export function ProjectList() {
   return (
     <nav className="flex flex-col gap-1">
       {data.map((p) => (
-        <NavLink
-          key={p.id}
-          to={`/p/${p.prefix}`}
-          className={({ isActive }) =>
-            `flex items-baseline gap-2 rounded-md px-3 py-1.5 text-sm ${
-              isActive
-                ? "bg-neutral-900 text-white dark:bg-white dark:text-neutral-900"
-                : "text-neutral-700 hover:bg-black/5 dark:text-neutral-300 dark:hover:bg-white/10"
-            }`
-          }
-        >
-          <span className="font-mono text-xs opacity-70">{p.prefix}</span>
-          <span className="truncate">{p.name}</span>
-        </NavLink>
+        <ProjectRow key={p.id} project={p} />
       ))}
     </nav>
   );

--- a/ui/src/components/sidebar/ProjectRow.tsx
+++ b/ui/src/components/sidebar/ProjectRow.tsx
@@ -1,0 +1,134 @@
+import { useState } from "react";
+import { NavLink, useNavigate, useParams } from "react-router";
+import type { ProjectDto } from "@/data/bindings";
+import { useApply } from "@/data/mutations";
+import { ops } from "@/data/ops";
+
+export interface ProjectRowProps {
+  project: ProjectDto;
+}
+
+export function ProjectRow({ project }: ProjectRowProps) {
+  const apply = useApply();
+  const navigate = useNavigate();
+  const { prefix: activePrefix } = useParams();
+  const isActive = activePrefix === project.prefix;
+
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [renaming, setRenaming] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+  const closeMenu = () => {
+    setMenuOpen(false);
+    setConfirmingDelete(false);
+  };
+
+  const commitRename = (raw: string) => {
+    const trimmed = raw.trim();
+    if (trimmed && trimmed !== project.name) {
+      apply.mutate(ops.updateProject({ id: project.id, name: trimmed }));
+    }
+    setRenaming(false);
+  };
+
+  const onArchive = () => {
+    apply.mutate(ops.archiveProject({ id: project.id }));
+    closeMenu();
+    if (isActive) navigate("/");
+  };
+
+  const onDelete = () => {
+    apply.mutate(ops.deleteProject({ id: project.id }));
+    closeMenu();
+    if (isActive) navigate("/");
+  };
+
+  if (renaming) {
+    return (
+      <div className="flex items-center px-3 py-1.5">
+        <input
+          aria-label="Rename project"
+          autoFocus
+          defaultValue={project.name}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              commitRename(e.currentTarget.value);
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              setRenaming(false);
+            }
+          }}
+          onBlur={(e) => commitRename(e.currentTarget.value)}
+          className="w-full rounded-md border border-black/10 bg-white px-2 py-1 text-sm dark:border-white/10 dark:bg-neutral-800"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="group relative flex items-center">
+      <NavLink
+        to={`/p/${project.prefix}`}
+        className={({ isActive: linkActive }) =>
+          `flex flex-1 items-baseline gap-2 rounded-md px-3 py-1.5 text-sm ${
+            linkActive
+              ? "bg-neutral-900 text-white dark:bg-white dark:text-neutral-900"
+              : "text-neutral-700 hover:bg-black/5 dark:text-neutral-300 dark:hover:bg-white/10"
+          }`
+        }
+      >
+        <span className="font-mono text-xs opacity-70">{project.prefix}</span>
+        <span className="truncate">{project.name}</span>
+      </NavLink>
+
+      <button
+        type="button"
+        aria-label={`Actions for ${project.prefix}`}
+        onClick={() => setMenuOpen((o) => !o)}
+        className="ml-1 rounded px-1.5 text-neutral-500 hover:bg-black/5 dark:hover:bg-white/10"
+      >
+        ⋯
+      </button>
+
+      {menuOpen && (
+        <div className="absolute right-0 top-full z-10 mt-1 flex w-36 flex-col rounded-md border border-black/10 bg-white py-1 text-sm shadow-lg dark:border-white/10 dark:bg-neutral-900">
+          <button
+            type="button"
+            onClick={() => {
+              setRenaming(true);
+              closeMenu();
+            }}
+            className="px-3 py-1.5 text-left hover:bg-black/5 dark:hover:bg-white/10"
+          >
+            Rename
+          </button>
+          <button
+            type="button"
+            onClick={onArchive}
+            className="px-3 py-1.5 text-left hover:bg-black/5 dark:hover:bg-white/10"
+          >
+            Archive
+          </button>
+          {confirmingDelete ? (
+            <button
+              type="button"
+              onClick={onDelete}
+              className="px-3 py-1.5 text-left text-red-600 hover:bg-red-500/10"
+            >
+              Confirm delete
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setConfirmingDelete(true)}
+              className="px-3 py-1.5 text-left text-red-600 hover:bg-red-500/10"
+            >
+              Delete
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/sidebar/ProjectRow.tsx
+++ b/ui/src/components/sidebar/ProjectRow.tsx
@@ -85,7 +85,12 @@ export function ProjectRow({ project }: ProjectRowProps) {
       <button
         type="button"
         aria-label={`Actions for ${project.prefix}`}
-        onClick={() => setMenuOpen((o) => !o)}
+        aria-haspopup="menu"
+        aria-expanded={menuOpen}
+        onClick={() => {
+          setMenuOpen((o) => !o);
+          setConfirmingDelete(false);
+        }}
         className="ml-1 rounded px-1.5 text-neutral-500 hover:bg-black/5 dark:hover:bg-white/10"
       >
         ⋯

--- a/ui/src/data/bindings.ts
+++ b/ui/src/data/bindings.ts
@@ -213,7 +213,7 @@ export type ApiError =
  * Result of applying an operation: the new `operation_log` row id.
  */
 export type ApplyResult = { op_id: number }
-export type IssueDto = { id: string; project_id: string; seq: number; identifier: string; title: string; description: string | null; status_id: string; priority: string; due_date: string | null; sort_key: number; created_at: string; updated_at: string }
+export type IssueDto = { id: string; project_id: string; seq: number; identifier: string; title: string; description: string | null; status_id: string; priority: string; due_date: string | null; sort_key: number; created_at: string; updated_at: string; labels: LabelDto[] | null }
 export type JsonValue = null | boolean | number | string | JsonValue[] | Partial<{ [key in string]: JsonValue }>
 export type LabelDto = { id: string; project_id: string; name: string; color: string }
 export type ProjectDto = { id: string; name: string; prefix: string; description: string | null; icon: string | null; status: string; created_at: string; updated_at: string }

--- a/ui/src/data/mutations.ts
+++ b/ui/src/data/mutations.ts
@@ -92,3 +92,39 @@ export function useApply(prefixForCache?: string) {
     onSettled: (_data, _err, op) => invalidateFor(qc, op, prefixForCache),
   });
 }
+
+/**
+ * Undo the last applied operation via `commands.undo`. Because undo can touch
+ * any entity, it invalidates every query on settle rather than scoping.
+ */
+export function useUndo() {
+  const qc = useQueryClient();
+  return useMutation<unknown, unknown, void>({
+    mutationFn: async () => {
+      const r = await commands.undo();
+      if (r.status !== "ok") throw asApiError(r.error);
+      return r.data;
+    },
+    onSettled: () => {
+      void qc.invalidateQueries();
+    },
+  });
+}
+
+/**
+ * Redo the last undone operation via `commands.redo`. Invalidates every query
+ * on settle (see `useUndo`).
+ */
+export function useRedo() {
+  const qc = useQueryClient();
+  return useMutation<unknown, unknown, void>({
+    mutationFn: async () => {
+      const r = await commands.redo();
+      if (r.status !== "ok") throw asApiError(r.error);
+      return r.data;
+    },
+    onSettled: () => {
+      void qc.invalidateQueries();
+    },
+  });
+}

--- a/ui/src/data/mutations.ts
+++ b/ui/src/data/mutations.ts
@@ -59,16 +59,14 @@ function invalidateFor(qc: QueryClient, op: Operation, prefix?: string): void {
   }
   if (["CreateIssue", "UpdateIssueField", "ReorderIssue", "DeleteIssue"].includes(tag)) {
     if (prefix) void qc.invalidateQueries({ queryKey: qk.issues(prefix) });
-    if (tag === "UpdateIssueField") {
-      const id = (op.args as Partial<WithId>).id;
-      if (id) void qc.invalidateQueries({ queryKey: qk.issue(id) });
-    }
+    void qc.invalidateQueries({ queryKey: ["issues"] }); // refresh any open detail panel
   }
   if (["AttachLabel", "DetachLabel", "CreateLabel", "UpdateLabel", "DeleteLabel"].includes(tag)) {
     if (prefix) {
       void qc.invalidateQueries({ queryKey: qk.labels(prefix) });
       void qc.invalidateQueries({ queryKey: qk.issues(prefix) });
     }
+    void qc.invalidateQueries({ queryKey: ["issues"] }); // detail panel chips
   }
   if (tag === "ImportSnapshot") void qc.invalidateQueries();
 }

--- a/ui/src/data/ops.ts
+++ b/ui/src/data/ops.ts
@@ -8,7 +8,8 @@
 //   - `ReorderIssue.new_sort_key` uses `serde_f64::bits` → a "0x"+16-hex string
 //     of the f64 big-endian bit pattern, NOT a plain JSON number.
 
-export type Priority = "none" | "low" | "medium" | "high" | "urgent";
+export const PRIORITIES = ["none", "low", "medium", "high", "urgent"] as const;
+export type Priority = (typeof PRIORITIES)[number];
 
 export type IssueFieldChange =
   | { field: "Title"; value: string }

--- a/ui/src/data/ops.ts
+++ b/ui/src/data/ops.ts
@@ -69,6 +69,47 @@ export const ops = {
   }),
 
   deleteIssue: (args: { id: string }): Operation => ({ op: "DeleteIssue", args }),
+
+  createLabel: (args: {
+    id: string;
+    project_id: string;
+    name: string;
+    color: string;
+  }): Operation => ({ op: "CreateLabel", args }),
+
+  updateLabel: (args: { id: string; name?: string; color?: string }): Operation => {
+    const patch: Record<string, unknown> = {};
+    if (args.name !== undefined) patch.name = args.name;
+    if (args.color !== undefined) patch.color = args.color;
+    return { op: "UpdateLabel", args: { id: args.id, patch } };
+  },
+
+  deleteLabel: (args: { id: string }): Operation => ({ op: "DeleteLabel", args }),
+
+  attachLabel: (args: { issue_id: string; label_id: string }): Operation => ({
+    op: "AttachLabel",
+    args,
+  }),
+
+  detachLabel: (args: { issue_id: string; label_id: string }): Operation => ({
+    op: "DetachLabel",
+    args,
+  }),
+
+  updateProject: (args: {
+    id: string;
+    name?: string;
+    description?: string | null;
+  }): Operation => {
+    const patch: Record<string, unknown> = {};
+    if (args.name !== undefined) patch.name = args.name;
+    if (args.description !== undefined) patch.description = args.description;
+    return { op: "UpdateProject", args: { id: args.id, patch } };
+  },
+
+  archiveProject: (args: { id: string }): Operation => ({ op: "ArchiveProject", args }),
+
+  deleteProject: (args: { id: string }): Operation => ({ op: "DeleteProject", args }),
 } as const;
 
 export const change = {

--- a/ui/src/lib/undoRedoKey.ts
+++ b/ui/src/lib/undoRedoKey.ts
@@ -1,0 +1,14 @@
+/** Classify a keyboard event into an undo/redo intent (⌘/Ctrl+Z, ⌘/Ctrl+Shift+Z, ⌘/Ctrl+Y). */
+export function classifyUndoRedo(e: {
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  key: string;
+}): "undo" | "redo" | null {
+  const mod = e.metaKey || e.ctrlKey;
+  if (!mod) return null;
+  const k = e.key.toLowerCase();
+  if (k === "z") return e.shiftKey ? "redo" : "undo";
+  if (k === "y") return "redo";
+  return null;
+}

--- a/ui/src/routes/_layout.tsx
+++ b/ui/src/routes/_layout.tsx
@@ -1,11 +1,61 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Outlet } from "react-router";
 import { TitleBar } from "@/components/chrome/TitleBar";
 import { ProjectList } from "@/components/sidebar/ProjectList";
 import { NewProjectDialog } from "@/components/sidebar/NewProjectDialog";
+import { useUndo, useRedo } from "@/data/mutations";
+import { classifyUndoRedo } from "@/lib/undoRedoKey";
+
+/** Safely pull a human message off an unknown thrown value (the `ApiError`). */
+function messageOf(e: unknown): string | undefined {
+  if (e && typeof e === "object" && "message" in e && typeof (e as { message: unknown }).message === "string") {
+    return (e as { message: string }).message;
+  }
+  return undefined;
+}
 
 export default function Layout() {
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
+  const undo = useUndo();
+  const redo = useRedo();
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    function showToast(msg: string) {
+      setToast(msg);
+      if (toastTimer.current) clearTimeout(toastTimer.current);
+      toastTimer.current = setTimeout(() => setToast(null), 1500);
+    }
+
+    function onKeyDown(e: KeyboardEvent) {
+      // Let native text-undo win inside editable fields.
+      const t = e.target as HTMLElement | null;
+      if (t && (t.isContentEditable || t.tagName === "INPUT" || t.tagName === "TEXTAREA")) return;
+
+      const intent = classifyUndoRedo(e);
+      if (!intent) return;
+      e.preventDefault();
+
+      if (intent === "undo") {
+        undo.mutate(undefined, {
+          onSuccess: () => showToast("Undone"),
+          onError: (err) => showToast(messageOf(err) ?? "Nothing to undo"),
+        });
+      } else {
+        redo.mutate(undefined, {
+          onSuccess: () => showToast("Redone"),
+          onError: (err) => showToast(messageOf(err) ?? "Nothing to redo"),
+        });
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      if (toastTimer.current) clearTimeout(toastTimer.current);
+    };
+  }, [undo, redo]);
 
   return (
     <div className="flex h-screen flex-col bg-white text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
@@ -31,6 +81,14 @@ export default function Layout() {
         </main>
       </div>
       <NewProjectDialog open={dialogOpen} onOpenChange={setDialogOpen} />
+      {toast && (
+        <div
+          role="status"
+          className="pointer-events-none fixed bottom-4 left-1/2 z-[60] -translate-x-1/2 rounded-md bg-neutral-900 px-3 py-1.5 text-xs text-white shadow-lg dark:bg-white dark:text-neutral-900"
+        >
+          {toast}
+        </div>
+      )}
     </div>
   );
 }

--- a/ui/tests/components/board/IssueCard.test.tsx
+++ b/ui/tests/components/board/IssueCard.test.tsx
@@ -19,6 +19,7 @@ const issue: IssueDto = {
   sort_key: 1,
   created_at: "",
   updated_at: "",
+  labels: null,
 };
 
 describe("IssueCard", () => {

--- a/ui/tests/components/detail/IssuePanel.test.tsx
+++ b/ui/tests/components/detail/IssuePanel.test.tsx
@@ -11,12 +11,14 @@ vi.mock("@/data/queries", () => ({
   useIssue: () => ({
     data: {
       id: "u1",
+      project_id: "p1",
       identifier: "AUTH-12",
       title: "Hello",
       description: "# body",
       status_id: "s1",
       priority: "medium",
       due_date: "2026-01-01",
+      labels: [{ id: "l1", project_id: "p1", name: "bug", color: "#f00" }],
     },
     isLoading: false,
     isError: false,
@@ -27,6 +29,7 @@ vi.mock("@/data/queries", () => ({
       { id: "s2", name: "Done", position: 2 },
     ],
   }),
+  useLabels: () => ({ data: [{ id: "l1", project_id: "p1", name: "bug", color: "#f00" }] }),
 }));
 vi.mock("@tauri-apps/plugin-shell", () => ({ open: vi.fn() }));
 
@@ -93,6 +96,17 @@ describe("IssuePanel", () => {
     const op = mutate.mock.calls.at(-1)?.[0] as { op: string; args: { change: unknown } };
     expect(op.op).toBe("UpdateIssueField");
     expect(op.args.change).toEqual({ field: "DueDate", value: null });
+  });
+
+  it("renders a chip for an attached label and detaches on remove", async () => {
+    mutate.mockReset();
+    render(<IssuePanel />, { wrapper });
+    expect(screen.getByText("bug")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /remove bug/i }));
+    expect(mutate).toHaveBeenCalled();
+    const op = mutate.mock.calls.at(-1)?.[0] as { op: string; args: Record<string, unknown> };
+    expect(op.op).toBe("DetachLabel");
+    expect(op.args).toEqual({ issue_id: "u1", label_id: "l1" });
   });
 
   it("dispatches deleteIssue after confirming delete", async () => {

--- a/ui/tests/components/detail/IssuePanel.test.tsx
+++ b/ui/tests/components/detail/IssuePanel.test.tsx
@@ -16,7 +16,7 @@ vi.mock("@/data/queries", () => ({
       description: "# body",
       status_id: "s1",
       priority: "medium",
-      due_date: null,
+      due_date: "2026-01-01",
     },
     isLoading: false,
     isError: false,
@@ -81,6 +81,18 @@ describe("IssuePanel", () => {
     const op = mutate.mock.calls.at(-1)?.[0] as { op: string; args: { change: unknown } };
     expect(op.op).toBe("UpdateIssueField");
     expect(op.args.change).toEqual({ field: "DueDate", value: "2026-12-31" });
+  });
+
+  it("clearing the due date dispatches a null value", () => {
+    mutate.mockReset();
+    render(<IssuePanel />, { wrapper });
+    fireEvent.change(screen.getByLabelText(/due date/i), {
+      target: { value: "" },
+    });
+    expect(mutate).toHaveBeenCalled();
+    const op = mutate.mock.calls.at(-1)?.[0] as { op: string; args: { change: unknown } };
+    expect(op.op).toBe("UpdateIssueField");
+    expect(op.args.change).toEqual({ field: "DueDate", value: null });
   });
 
   it("dispatches deleteIssue after confirming delete", async () => {

--- a/ui/tests/components/detail/IssuePanel.test.tsx
+++ b/ui/tests/components/detail/IssuePanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Routes, Route } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -15,7 +15,8 @@ vi.mock("@/data/queries", () => ({
       title: "Hello",
       description: "# body",
       status_id: "s1",
-      priority: "high",
+      priority: "medium",
+      due_date: null,
     },
     isLoading: false,
     isError: false,
@@ -53,10 +54,43 @@ describe("IssuePanel", () => {
   it("dispatches updateIssueField on status change", async () => {
     mutate.mockReset();
     render(<IssuePanel />, { wrapper });
-    await userEvent.selectOptions(screen.getByRole("combobox"), "s2");
+    await userEvent.selectOptions(screen.getByLabelText(/status/i), "s2");
     expect(mutate).toHaveBeenCalled();
     const op = mutate.mock.calls.at(-1)?.[0] as { op: string; args: { change: unknown } };
     expect(op.op).toBe("UpdateIssueField");
     expect(op.args.change).toEqual({ field: "Status", value: "s2" });
+  });
+
+  it("dispatches updateIssueField on priority change", async () => {
+    mutate.mockReset();
+    render(<IssuePanel />, { wrapper });
+    await userEvent.selectOptions(screen.getByLabelText(/priority/i), "high");
+    expect(mutate).toHaveBeenCalled();
+    const op = mutate.mock.calls.at(-1)?.[0] as { op: string; args: { change: unknown } };
+    expect(op.op).toBe("UpdateIssueField");
+    expect(op.args.change).toEqual({ field: "Priority", value: "high" });
+  });
+
+  it("dispatches updateIssueField on due-date change", () => {
+    mutate.mockReset();
+    render(<IssuePanel />, { wrapper });
+    fireEvent.change(screen.getByLabelText(/due date/i), {
+      target: { value: "2026-12-31" },
+    });
+    expect(mutate).toHaveBeenCalled();
+    const op = mutate.mock.calls.at(-1)?.[0] as { op: string; args: { change: unknown } };
+    expect(op.op).toBe("UpdateIssueField");
+    expect(op.args.change).toEqual({ field: "DueDate", value: "2026-12-31" });
+  });
+
+  it("dispatches deleteIssue after confirming delete", async () => {
+    mutate.mockReset();
+    render(<IssuePanel />, { wrapper });
+    await userEvent.click(screen.getByRole("button", { name: /^delete$/i }));
+    await userEvent.click(screen.getByRole("button", { name: /confirm/i }));
+    expect(mutate).toHaveBeenCalled();
+    const op = mutate.mock.calls.at(-1)?.[0] as { op: string; args: { id: string } };
+    expect(op.op).toBe("DeleteIssue");
+    expect(op.args.id).toBe("u1");
   });
 });

--- a/ui/tests/components/detail/LabelPicker.test.tsx
+++ b/ui/tests/components/detail/LabelPicker.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { LabelDto } from "@/data/bindings";
+
+const mutate = vi.hoisted(() => vi.fn());
+const labels = vi.hoisted<() => LabelDto[]>(() => () => [
+  { id: "l1", project_id: "p1", name: "bug", color: "#f00" },
+  { id: "l2", project_id: "p1", name: "feature", color: "#0f0" },
+]);
+
+vi.mock("@/data/mutations", () => ({ useApply: () => ({ mutate, isPending: false }) }));
+vi.mock("@/data/queries", () => ({ useLabels: () => ({ data: labels() }) }));
+
+import { LabelPicker } from "@/components/detail/LabelPicker";
+
+type Op = { op: string; args: Record<string, unknown> };
+const lastOp = () => mutate.mock.calls.at(-1)?.[0] as Op;
+
+function renderPicker(attached: LabelDto[] = []) {
+  return render(
+    <LabelPicker prefix="AUTH" issueId="u1" projectId="p1" attached={attached} />,
+  );
+}
+
+describe("LabelPicker", () => {
+  it("opening the picker lists every project label", async () => {
+    mutate.mockReset();
+    renderPicker();
+    await userEvent.click(screen.getByRole("button", { name: /labels/i }));
+    expect(screen.getByText("bug")).toBeInTheDocument();
+    expect(screen.getByText("feature")).toBeInTheDocument();
+  });
+
+  it("clicking an unattached label dispatches AttachLabel", async () => {
+    mutate.mockReset();
+    renderPicker([]);
+    await userEvent.click(screen.getByRole("button", { name: /labels/i }));
+    await userEvent.click(screen.getByRole("button", { name: /^bug$/i }));
+    const op = lastOp();
+    expect(op.op).toBe("AttachLabel");
+    expect(op.args).toEqual({ issue_id: "u1", label_id: "l1" });
+  });
+
+  it("clicking an attached label dispatches DetachLabel", async () => {
+    mutate.mockReset();
+    renderPicker([{ id: "l1", project_id: "p1", name: "bug", color: "#f00" }]);
+    await userEvent.click(screen.getByRole("button", { name: /labels/i }));
+    await userEvent.click(screen.getByRole("button", { name: /^bug$/i }));
+    const op = lastOp();
+    expect(op.op).toBe("DetachLabel");
+    expect(op.args).toEqual({ issue_id: "u1", label_id: "l1" });
+  });
+
+  it("typing a name and clicking Add dispatches CreateLabel", async () => {
+    mutate.mockReset();
+    renderPicker();
+    await userEvent.click(screen.getByRole("button", { name: /labels/i }));
+    await userEvent.type(screen.getByLabelText(/new label name/i), "urgent");
+    await userEvent.click(screen.getByRole("button", { name: /^add$/i }));
+    const op = lastOp();
+    expect(op.op).toBe("CreateLabel");
+    expect(op.args).toMatchObject({ project_id: "p1", name: "urgent" });
+    expect(typeof op.args.id).toBe("string");
+    expect((op.args.id as string).length).toBeGreaterThan(0);
+    expect(typeof op.args.color).toBe("string");
+  });
+});

--- a/ui/tests/components/sidebar/ProjectList.test.tsx
+++ b/ui/tests/components/sidebar/ProjectList.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter } from "react-router";
 import { describe, expect, it, vi } from "vitest";
 import { ProjectList } from "@/components/sidebar/ProjectList";
 
+vi.mock("@/data/mutations", () => ({ useApply: () => ({ mutate: vi.fn(), isPending: false }) }));
 vi.mock("@/data/queries", () => ({
   useProjects: () => ({
     data: [

--- a/ui/tests/components/sidebar/ProjectRow.test.tsx
+++ b/ui/tests/components/sidebar/ProjectRow.test.tsx
@@ -108,6 +108,20 @@ describe("ProjectRow", () => {
     expect(op.args).toEqual({ id: "p1" });
   });
 
+  it("toggling the menu resets a pending delete confirmation", async () => {
+    mutate.mockReset();
+    renderRow();
+    await userEvent.click(screen.getByRole("button", { name: /actions for AUTH/i }));
+    await userEvent.click(screen.getByRole("button", { name: /^delete$/i }));
+    expect(screen.getByRole("button", { name: /confirm delete/i })).toBeInTheDocument();
+    // Close then reopen the menu — the confirm state must NOT persist.
+    await userEvent.click(screen.getByRole("button", { name: /actions for AUTH/i }));
+    await userEvent.click(screen.getByRole("button", { name: /actions for AUTH/i }));
+    expect(screen.queryByRole("button", { name: /confirm delete/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^delete$/i })).toBeInTheDocument();
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
   it("archiving the active project navigates home", async () => {
     mutate.mockReset();
     navigate.mockReset();

--- a/ui/tests/components/sidebar/ProjectRow.test.tsx
+++ b/ui/tests/components/sidebar/ProjectRow.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Routes, Route } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import type { ProjectDto } from "@/data/bindings";
+
+const mutate = vi.hoisted(() => vi.fn());
+const navigate = vi.hoisted(() => vi.fn());
+
+vi.mock("@/data/mutations", () => ({ useApply: () => ({ mutate, isPending: false }) }));
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual<typeof import("react-router")>("react-router");
+  return { ...actual, useNavigate: () => navigate };
+});
+
+import { ProjectRow } from "@/components/sidebar/ProjectRow";
+
+const project: ProjectDto = {
+  id: "p1",
+  name: "Auth",
+  prefix: "AUTH",
+  description: null,
+  icon: null,
+  status: "active",
+  created_at: "",
+  updated_at: "",
+};
+
+function renderRow(at = "/p/PAY") {
+  return render(
+    <MemoryRouter initialEntries={[at]}>
+      <Routes>
+        <Route path="/p/:prefix" element={<ProjectRow project={project} />} />
+        <Route path="/" element={<ProjectRow project={project} />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("ProjectRow", () => {
+  it("renders the project's prefix and name as a link", () => {
+    renderRow();
+    expect(screen.getByText("AUTH")).toBeInTheDocument();
+    expect(screen.getByText("Auth")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /AUTH/ })).toHaveAttribute("href", "/p/AUTH");
+  });
+
+  it("rename dispatches UpdateProject with the new name", async () => {
+    mutate.mockReset();
+    renderRow();
+    await userEvent.click(screen.getByRole("button", { name: /actions for AUTH/i }));
+    await userEvent.click(screen.getByRole("button", { name: /^rename$/i }));
+    const input = screen.getByRole("textbox", { name: /rename project/i });
+    await userEvent.clear(input);
+    await userEvent.type(input, "Authentication{enter}");
+    expect(mutate).toHaveBeenCalledTimes(1);
+    const op = mutate.mock.calls.at(-1)?.[0] as {
+      op: string;
+      args: { id: string; patch: { name: string } };
+    };
+    expect(op.op).toBe("UpdateProject");
+    expect(op.args).toEqual({ id: "p1", patch: { name: "Authentication" } });
+  });
+
+  it("rename with an unchanged name dispatches nothing", async () => {
+    mutate.mockReset();
+    renderRow();
+    await userEvent.click(screen.getByRole("button", { name: /actions for AUTH/i }));
+    await userEvent.click(screen.getByRole("button", { name: /^rename$/i }));
+    const input = screen.getByRole("textbox", { name: /rename project/i });
+    await userEvent.type(input, "{enter}");
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it("rename Escape cancels without dispatching", async () => {
+    mutate.mockReset();
+    renderRow();
+    await userEvent.click(screen.getByRole("button", { name: /actions for AUTH/i }));
+    await userEvent.click(screen.getByRole("button", { name: /^rename$/i }));
+    const input = screen.getByRole("textbox", { name: /rename project/i });
+    await userEvent.clear(input);
+    await userEvent.type(input, "Nope{escape}");
+    expect(mutate).not.toHaveBeenCalled();
+    expect(screen.queryByRole("textbox", { name: /rename project/i })).not.toBeInTheDocument();
+  });
+
+  it("archive dispatches ArchiveProject", async () => {
+    mutate.mockReset();
+    renderRow();
+    await userEvent.click(screen.getByRole("button", { name: /actions for AUTH/i }));
+    await userEvent.click(screen.getByRole("button", { name: /^archive$/i }));
+    expect(mutate).toHaveBeenCalledTimes(1);
+    const op = mutate.mock.calls.at(-1)?.[0] as { op: string; args: { id: string } };
+    expect(op.op).toBe("ArchiveProject");
+    expect(op.args).toEqual({ id: "p1" });
+  });
+
+  it("delete dispatches DeleteProject only after confirming", async () => {
+    mutate.mockReset();
+    renderRow();
+    await userEvent.click(screen.getByRole("button", { name: /actions for AUTH/i }));
+    await userEvent.click(screen.getByRole("button", { name: /^delete$/i }));
+    expect(mutate).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByRole("button", { name: /confirm delete/i }));
+    expect(mutate).toHaveBeenCalledTimes(1);
+    const op = mutate.mock.calls.at(-1)?.[0] as { op: string; args: { id: string } };
+    expect(op.op).toBe("DeleteProject");
+    expect(op.args).toEqual({ id: "p1" });
+  });
+
+  it("archiving the active project navigates home", async () => {
+    mutate.mockReset();
+    navigate.mockReset();
+    renderRow("/p/AUTH");
+    await userEvent.click(screen.getByRole("button", { name: /actions for AUTH/i }));
+    await userEvent.click(screen.getByRole("button", { name: /^archive$/i }));
+    expect(navigate).toHaveBeenCalledWith("/");
+  });
+
+  it("deleting the active project navigates home", async () => {
+    mutate.mockReset();
+    navigate.mockReset();
+    renderRow("/p/AUTH");
+    await userEvent.click(screen.getByRole("button", { name: /actions for AUTH/i }));
+    await userEvent.click(screen.getByRole("button", { name: /^delete$/i }));
+    await userEvent.click(screen.getByRole("button", { name: /confirm delete/i }));
+    expect(navigate).toHaveBeenCalledWith("/");
+  });
+
+  it("archiving a non-active project does not navigate", async () => {
+    mutate.mockReset();
+    navigate.mockReset();
+    renderRow("/p/PAY");
+    await userEvent.click(screen.getByRole("button", { name: /actions for AUTH/i }));
+    await userEvent.click(screen.getByRole("button", { name: /^archive$/i }));
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});

--- a/ui/tests/data/mutations.test.tsx
+++ b/ui/tests/data/mutations.test.tsx
@@ -47,6 +47,20 @@ describe("useApply optimistic dispatcher", () => {
     expect(cache?.map((i) => i.id)).toEqual(["u1", "u2"]); // rolled back
   });
 
+  it("invalidates the issues key-space on AttachLabel so the open panel refetches", async () => {
+    applyMock.mockResolvedValueOnce({ status: "ok", data: { op_id: 8 } });
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+
+    const { result } = renderHook(() => useApply("AUTH"), { wrapper: makeWrapper(client) });
+    await act(async () => {
+      result.current.mutate(ops.attachLabel({ issue_id: "u1", label_id: "l1" }));
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["issues"] });
+  });
+
   it("optimistically adds a created project to the cache on success", async () => {
     applyMock.mockResolvedValueOnce({ status: "ok", data: { op_id: 7 } });
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/ui/tests/data/mutations.test.tsx
+++ b/ui/tests/data/mutations.test.tsx
@@ -5,16 +5,22 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // `vi.hoisted` so the mock factory (hoisted above module init) can reference it.
 const applyMock = vi.hoisted(() => vi.fn());
+const undoMock = vi.hoisted(() => vi.fn());
+const redoMock = vi.hoisted(() => vi.fn());
 vi.mock("@/data/bindings", () => ({
-  commands: { apply: applyMock, undo: vi.fn(), redo: vi.fn(), updateSettings: vi.fn() },
+  commands: { apply: applyMock, undo: undoMock, redo: redoMock, updateSettings: vi.fn() },
 }));
 
 beforeEach(() => {
   applyMock.mockReset();
   applyMock.mockResolvedValue({ status: "ok", data: { op_id: 42 } });
+  undoMock.mockReset();
+  undoMock.mockResolvedValue({ status: "ok", data: null });
+  redoMock.mockReset();
+  redoMock.mockResolvedValue({ status: "ok", data: null });
 });
 
-import { useApply } from "@/data/mutations";
+import { useApply, useUndo, useRedo } from "@/data/mutations";
 import { ops } from "@/data/ops";
 import { qk } from "@/data/queries";
 
@@ -54,5 +60,48 @@ describe("useApply optimistic dispatcher", () => {
 
     const cache = client.getQueryData<Array<{ prefix: string }>>(qk.projects());
     expect(cache?.map((p) => p.prefix)).toContain("PAY");
+  });
+});
+
+describe("useUndo / useRedo", () => {
+  it("useUndo calls commands.undo and invalidates queries", async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+
+    const { result } = renderHook(() => useUndo(), { wrapper: makeWrapper(client) });
+    await act(async () => {
+      result.current.mutate();
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    });
+
+    expect(undoMock).toHaveBeenCalledTimes(1);
+    expect(invalidateSpy).toHaveBeenCalled();
+  });
+
+  it("useRedo calls commands.redo and invalidates queries", async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+
+    const { result } = renderHook(() => useRedo(), { wrapper: makeWrapper(client) });
+    await act(async () => {
+      result.current.mutate();
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    });
+
+    expect(redoMock).toHaveBeenCalledTimes(1);
+    expect(invalidateSpy).toHaveBeenCalled();
+  });
+
+  it("useUndo surfaces an error when the command fails", async () => {
+    undoMock.mockResolvedValueOnce({ status: "error", error: { kind: "Validation", message: "nothing to undo" } });
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    const { result } = renderHook(() => useUndo(), { wrapper: makeWrapper(client) });
+    await act(async () => {
+      result.current.mutate();
+      await waitFor(() => expect(result.current.isError).toBe(true));
+    });
+
+    expect(result.current.error).toMatchObject({ kind: "Validation", message: "nothing to undo" });
   });
 });

--- a/ui/tests/data/ops.test.ts
+++ b/ui/tests/data/ops.test.ts
@@ -43,4 +43,45 @@ describe("ops builders", () => {
       args: { id: "u2", new_sort_key: "0x3ff8000000000000" },
     });
   });
+
+  it("createLabel wraps args", () => {
+    expect(ops.createLabel({ id: "l1", project_id: "p1", name: "bug", color: "#f00" })).toEqual({
+      op: "CreateLabel",
+      args: { id: "l1", project_id: "p1", name: "bug", color: "#f00" },
+    });
+  });
+
+  it("attachLabel uses issue_id + label_id", () => {
+    expect(ops.attachLabel({ issue_id: "u1", label_id: "l1" })).toEqual({
+      op: "AttachLabel",
+      args: { issue_id: "u1", label_id: "l1" },
+    });
+  });
+
+  it("detachLabel uses issue_id + label_id", () => {
+    expect(ops.detachLabel({ issue_id: "u1", label_id: "l1" })).toEqual({
+      op: "DetachLabel",
+      args: { issue_id: "u1", label_id: "l1" },
+    });
+  });
+
+  it("updateProject wraps a name patch", () => {
+    expect(ops.updateProject({ id: "p1", name: "Renamed" })).toEqual({
+      op: "UpdateProject",
+      args: { id: "p1", patch: { name: "Renamed" } },
+    });
+  });
+
+  it("updateLabel wraps a patch", () => {
+    expect(ops.updateLabel({ id: "l1", color: "#0f0" })).toEqual({
+      op: "UpdateLabel",
+      args: { id: "l1", patch: { color: "#0f0" } },
+    });
+  });
+
+  it("archiveProject / deleteProject / deleteLabel take just id", () => {
+    expect(ops.archiveProject({ id: "p1" })).toEqual({ op: "ArchiveProject", args: { id: "p1" } });
+    expect(ops.deleteProject({ id: "p1" })).toEqual({ op: "DeleteProject", args: { id: "p1" } });
+    expect(ops.deleteLabel({ id: "l1" })).toEqual({ op: "DeleteLabel", args: { id: "l1" } });
+  });
 });

--- a/ui/tests/lib/undoRedoKey.test.ts
+++ b/ui/tests/lib/undoRedoKey.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { classifyUndoRedo } from "@/lib/undoRedoKey";
+
+const base = { metaKey: false, ctrlKey: false, shiftKey: false, key: "z" };
+
+describe("classifyUndoRedo", () => {
+  it("classifies ⌘Z as undo", () => {
+    expect(classifyUndoRedo({ ...base, metaKey: true, key: "z" })).toBe("undo");
+  });
+  it("classifies ⌘⇧Z as redo", () => {
+    expect(classifyUndoRedo({ ...base, metaKey: true, shiftKey: true, key: "z" })).toBe("redo");
+  });
+  it("classifies Ctrl+Z as undo", () => {
+    expect(classifyUndoRedo({ ...base, ctrlKey: true, key: "z" })).toBe("undo");
+  });
+  it("classifies Ctrl+Y as redo", () => {
+    expect(classifyUndoRedo({ ...base, ctrlKey: true, key: "y" })).toBe("redo");
+  });
+  it("classifies ⌘Y as redo", () => {
+    expect(classifyUndoRedo({ ...base, metaKey: true, key: "y" })).toBe("redo");
+  });
+  it("handles uppercase keys", () => {
+    expect(classifyUndoRedo({ ...base, metaKey: true, key: "Z" })).toBe("undo");
+    expect(classifyUndoRedo({ ...base, metaKey: true, shiftKey: true, key: "Z" })).toBe("redo");
+  });
+  it("returns null for a plain z (no modifier)", () => {
+    expect(classifyUndoRedo({ ...base, key: "z" })).toBeNull();
+  });
+  it("returns null for ⌘A (modifier but not z/y)", () => {
+    expect(classifyUndoRedo({ ...base, metaKey: true, key: "a" })).toBeNull();
+  });
+});

--- a/ui/tests/routes/_layout.test.tsx
+++ b/ui/tests/routes/_layout.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoisted command mocks so the `vi.mock` factory can reference them.
+const undoMock = vi.hoisted(() => vi.fn());
+const redoMock = vi.hoisted(() => vi.fn());
+const okEmpty = vi.hoisted(() => () => Promise.resolve({ status: "ok", data: [] }));
+
+vi.mock("@/data/bindings", () => ({
+  commands: {
+    apply: vi.fn(),
+    undo: undoMock,
+    redo: redoMock,
+    listProjects: okEmpty,
+    listIssues: okEmpty,
+    listStatuses: okEmpty,
+    listLabels: okEmpty,
+    getIssue: () => Promise.resolve({ status: "ok", data: null }),
+    getSettings: () => Promise.resolve({ status: "ok", data: { theme: "system" } }),
+    updateSettings: vi.fn(() => Promise.resolve({ status: "ok", data: null })),
+  },
+}));
+
+beforeEach(() => {
+  undoMock.mockReset();
+  undoMock.mockResolvedValue({ status: "ok", data: null });
+  redoMock.mockReset();
+  redoMock.mockResolvedValue({ status: "ok", data: null });
+});
+
+import Layout from "@/routes/_layout";
+
+function renderLayout() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const router = createMemoryRouter([{ path: "/", element: <Layout /> }], { initialEntries: ["/"] });
+  return render(
+    <QueryClientProvider client={client}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
+}
+
+function press(key: string, init: Partial<KeyboardEventInit> = {}) {
+  window.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true, ...init }));
+}
+
+describe("Layout undo/redo keyboard handler", () => {
+  it("fires undo on ⌘Z and shows a toast", async () => {
+    renderLayout();
+    press("z", { metaKey: true });
+    await waitFor(() => expect(undoMock).toHaveBeenCalledTimes(1));
+    expect(await screen.findByRole("status")).toHaveTextContent("Undone");
+  });
+
+  it("fires redo on ⌘⇧Z", async () => {
+    renderLayout();
+    press("z", { metaKey: true, shiftKey: true });
+    await waitFor(() => expect(redoMock).toHaveBeenCalledTimes(1));
+    expect(undoMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores ⌘Z when an input is focused", async () => {
+    renderLayout();
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+    // dispatch with the input as the target
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "z", metaKey: true, bubbles: true, cancelable: true }),
+    );
+    // give any microtasks a chance, then assert undo never ran
+    await Promise.resolve();
+    expect(undoMock).not.toHaveBeenCalled();
+    input.remove();
+  });
+});


### PR DESCRIPTION
## Summary

**Spec #4 — GUI Product Completeness**: closes the daily-driver gaps in the desktop app, all on top of the existing `kanban-core` operations (the generic `apply` command dispatches any of the 14 `Operation` variants). Built test-first across 8 feature tasks.

**Issue detail panel**
- Edit **priority** and **due date** (clearable); **delete** an issue (inline confirm) → returns to the board.
- **Labels**: colored chips, a label picker to attach/detach project labels, and create-a-label — backed by a new core read `Workspace::query_labels_for_issue`, surfaced as `IssueDto.labels: Option<Vec<LabelDto>>` (populated by `get_issue`, `None` for `list_issues`; one bindings regen).

**Sidebar**
- **Rename / archive / delete** a project from a per-row menu (delete has a confirm; removing the active project navigates home).

**Undo/redo**
- `⌘Z` / `⌘⇧Z` wired to `commands.undo`/`redo` with broad query invalidation and a toast; the handler ignores text inputs so ⌘Z still does native text-undo while editing.

**Fixes along the way**
- Repaired a latent cache bug: the detail-panel query keys by issue identifier, but `invalidateFor` invalidated by UUID — they never matched, so edits didn't refresh the open panel. Now invalidates the `["issues"]` keyspace.
- Reset the project delete-confirm state on menu toggle (was a destructive-action guard bypass).

**New `ops.ts` builders:** label + project operations (`createLabel`/`updateLabel`/`deleteLabel`/`attachLabel`/`detachLabel`/`updateProject`/`archiveProject`/`deleteProject`), shapes verified against core.

**Deferred to Spec #5+ (need new core operations / schema):** custom statuses (no `CreateStatus`/`UpdateStatus`/`DeleteStatus` op), members/assignee (not in schema), board-card label chips (needs `list_issues` to carry labels).

## Test plan
- [x] Rust: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` — all green (incl. the new `query_labels_for_issue` test + bindings drift guard).
- [x] UI: `pnpm typecheck`, `pnpm lint` (no `any`), `pnpm test:unit` (75 tests), `pnpm build` — all green.
- [x] Every write goes through `apply` → `Workspace::apply` (single-mutator invariant); no new migration.
- [ ] Manual smoke in the running app: set priority/due-date, attach/create labels, delete an issue and ⌘Z it back, rename/archive/delete a project.