### PR TITLE
v2: Spec #5 — Custom Statuses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,9 @@ The GUI is `crates/kanban-tauri` (Rust shell) + `ui/` (Vite + React 19 + Tailwin
 - **No live cross-process watcher.** The GUI refetches on window focus (`refetchOnWindowFocus`); a SQLite `update_hook` watcher is deferred to a later spec.
 - **E2E (`tauri-driver`) is deferred to a later spec** (no macOS WebDriver support); Spec #2 ships Vitest + RTL coverage. See `ui/e2e/README.md`.
 - **UI tooling on Apple Silicon:** if the default `node` is x86_64 (nvm), run ui scripts under a native arm64 node (`PATH="/opt/homebrew/bin:$PATH" npx pnpm@9.12.0 …`) or rollup/esbuild crash. If `node_modules` ends up with the wrong-arch rollup binary (a plain `install` reports "up to date" but `build` fails on `@rollup/rollup-darwin-arm64`), repair with `… pnpm@9.12.0 install --force`. `test:unit` can pass while `build` fails, so always run `build`. See `DEVELOPMENT.md`.
-- **GUI product completeness (Spec #4).** Issue detail-panel editing of priority, due date, and labels (chips + attach/detach/create), issue delete, ⌘Z/⌘⇧Z undo-redo (wrapping `commands.undo`/`redo` + broad query invalidation), and project rename/archive/delete from the sidebar — all via `ops.ts` builders through `apply`. The one core addition is `Workspace::query_labels_for_issue`, surfaced by `get_issue` as `IssueDto.labels: Option<Vec<LabelDto>>` (None for `list_issues`). Custom statuses (no status `Operation`) and members/assignee (not in schema) remain deferred to Spec #5+.
+- **GUI product completeness (Spec #4).** Issue detail-panel editing of priority, due date, and labels (chips + attach/detach/create), issue delete, ⌘Z/⌘⇧Z undo-redo (wrapping `commands.undo`/`redo` + broad query invalidation), and project rename/archive/delete from the sidebar — all via `ops.ts` builders through `apply`. The one core addition is `Workspace::query_labels_for_issue`, surfaced by `get_issue` as `IssueDto.labels: Option<Vec<LabelDto>>` (None for `list_issues`). Members/assignee (not in schema) remain deferred to Spec #6.
+
+- **Custom statuses (Spec #5).** Four undoable core ops — `CreateStatus`, `UpdateStatus` (via `StatusPatch`), `DeleteStatus`, `ReorderStatus` — mirroring the label ops (`apply/statuses.rs` + `store/{write,read}/statuses.rs` + `apply/mod.rs` arms; no migration, no DTO change). **`DeleteStatus` is guarded:** it refuses (`Error::Conflict`) if the status still has issues or is the project's last column (block-until-empty). `ReorderStatus` re-packs the project's columns to dense `0..n` positions; its undo inverse is an `ImportSnapshot` of the project's prior status ordering (delete's inverse snapshots the single row). Exposed in the GUI (board column add/rename/recolor/reorder/delete) and the CLI (`kanban status create/update/delete/reorder`); the generic Tauri `apply` and the MCP server need no changes.
 
 ## MCP layer (Spec #3)
 
@@ -94,5 +96,6 @@ These don't block v1 but should be addressed before broader release:
 - `docs/superpowers/specs/2026-05-05-kanban-v2-spec-2-gui-shell-design.md` — Spec #2 (Tauri GUI shell).
 - `docs/superpowers/specs/2026-06-05-kanban-v2-spec-3-mcp-server-design.md` — Spec #3 (MCP server).
 - `docs/superpowers/specs/2026-06-06-kanban-v2-spec-4-gui-product-completeness-design.md` — Spec #4 (GUI product completeness).
+- `docs/superpowers/specs/2026-06-06-kanban-v2-spec-5-custom-statuses-design.md` — Spec #5 (custom statuses).
 
-Each spec has a matching plan in `docs/superpowers/plans/`. Custom statuses, members/assignee, and AI-agent orchestration (Spec #5+) will live alongside.
+Each spec has a matching plan in `docs/superpowers/plans/`. Members/assignee (Spec #6) and AI-agent orchestration will live alongside.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ By default the workspace lives at `~/.kanban/data.db`. Override with `KANBAN_DB=
 ## Desktop app
 
 A macOS desktop GUI (Tauri + React) ships alongside the CLI, built on the same
-`kanban-core` library: a drag-and-drop kanban board, a markdown issue detail
-panel with priority / due-date / label editing and delete, a project sidebar
-with rename / archive / delete, ⌘Z / ⌘⇧Z undo-redo, and light/dark/system
+`kanban-core` library: a drag-and-drop kanban board with editable columns
+(add / rename / recolor / reorder / delete), a markdown issue detail panel
+with priority / due-date / label editing and delete, a project sidebar with
+rename / archive / delete, ⌘Z / ⌘⇧Z undo-redo, and light/dark/system
 theming.
 
 Download the latest macOS DMG from

--- a/crates/kanban-cli/src/cmd/status.rs
+++ b/crates/kanban-cli/src/cmd/status.rs
@@ -1,8 +1,15 @@
-//! `kanban status` subcommand. Read-only listing of statuses per project.
+//! `kanban status` subcommands.
+//!
+//! Statuses are scoped to a project and addressed by name within that project.
+//! Besides the read-only `list`, this module provides `create`, `update`,
+//! `delete`, and `reorder` write subcommands mirroring `kanban label`.
 
 use crate::output::Out;
 use clap::{Args, Subcommand};
-use kanban_core::{Project, Result, Workspace};
+use kanban_core::operation::{
+    CreateStatus, DeleteStatus, Operation, ReorderStatus, StatusPatch, UpdateStatus,
+};
+use kanban_core::{Project, Result, Status, StatusCategory, Workspace, new_id};
 use uuid::Uuid;
 
 #[derive(Debug, Args)]
@@ -18,6 +25,53 @@ pub enum StatusSub {
         #[arg(long)]
         project: String,
     },
+    /// Create a status.
+    Create {
+        #[arg(long)]
+        project: String,
+        #[arg(long)]
+        name: String,
+        /// One of: unstarted, started, blocked, completed, discarded.
+        #[arg(long)]
+        category: String,
+        #[arg(long)]
+        color: String,
+        /// Zero-based position. Defaults to appending after the last status.
+        #[arg(long)]
+        position: Option<i64>,
+    },
+    /// Update an existing status by current name.
+    Update {
+        #[arg(long)]
+        project: String,
+        #[arg(long)]
+        name: String,
+        #[arg(long)]
+        rename: Option<String>,
+        /// One of: unstarted, started, blocked, completed, discarded.
+        #[arg(long)]
+        category: Option<String>,
+        #[arg(long)]
+        color: Option<String>,
+    },
+    /// Delete a status (requires `--yes`).
+    Delete {
+        #[arg(long)]
+        project: String,
+        #[arg(long)]
+        name: String,
+        #[arg(long)]
+        yes: bool,
+    },
+    /// Reorder a status to a new zero-based position.
+    Reorder {
+        #[arg(long)]
+        project: String,
+        #[arg(long)]
+        name: String,
+        #[arg(long)]
+        position: i64,
+    },
 }
 
 /// Dispatch a `kanban status` invocation.
@@ -27,9 +81,48 @@ pub enum StatusSub {
 /// Propagates errors from the underlying [`Workspace`] operations and from
 /// validation in the dispatched subcommand handlers.
 #[allow(clippy::needless_pass_by_value)]
-pub fn run(cmd: StatusCmd, ws: &Workspace, out: &Out) -> Result<()> {
+pub fn run(cmd: StatusCmd, ws: &mut Workspace, out: &Out) -> Result<()> {
     match cmd.sub {
         StatusSub::List { project } => list(ws, out, &project),
+        StatusSub::Create {
+            project,
+            name,
+            category,
+            color,
+            position,
+        } => create(ws, out, &project, name, &category, color, position),
+        StatusSub::Update {
+            project,
+            name,
+            rename,
+            category,
+            color,
+        } => update(ws, out, &project, &name, rename, category, color),
+        StatusSub::Delete { project, name, yes } => delete(ws, out, &project, &name, yes),
+        StatusSub::Reorder {
+            project,
+            name,
+            position,
+        } => reorder(ws, out, &project, &name, position),
+    }
+}
+
+fn parse_category(s: &str) -> Result<StatusCategory> {
+    match s {
+        "unstarted" => Ok(StatusCategory::Unstarted),
+        "started" => Ok(StatusCategory::Started),
+        "blocked" => Ok(StatusCategory::Blocked),
+        "completed" => Ok(StatusCategory::Completed),
+        "discarded" => Ok(StatusCategory::Discarded),
+        other => Err(kanban_core::Error::Validation(
+            kanban_core::ValidationError {
+                field: "category".into(),
+                reason: format!(
+                    "unknown category '{other}'; expected one of \
+                     unstarted|started|blocked|completed|discarded"
+                ),
+            },
+        )),
     }
 }
 
@@ -46,6 +139,16 @@ fn resolve_project(ws: &Workspace, id_or_prefix: &str) -> Result<Project> {
         })
 }
 
+fn resolve_status_in_project(ws: &Workspace, project_id: Uuid, name: &str) -> Result<Status> {
+    ws.query_statuses_for_project(project_id)?
+        .into_iter()
+        .find(|s| s.name == name)
+        .ok_or(kanban_core::Error::NotFound {
+            kind: kanban_core::EntityKind::Status,
+            id: name.to_string(),
+        })
+}
+
 fn list(ws: &Workspace, out: &Out, project: &str) -> Result<()> {
     let p = resolve_project(ws, project)?;
     let statuses = ws.query_statuses_for_project(p.id)?;
@@ -57,4 +160,125 @@ fn list(ws: &Workspace, out: &Out, project: &str) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn create(
+    ws: &mut Workspace,
+    out: &Out,
+    project: &str,
+    name: String,
+    category: &str,
+    color: String,
+    position: Option<i64>,
+) -> Result<()> {
+    let p = resolve_project(ws, project)?;
+    let category = parse_category(category)?;
+    let position = match position {
+        Some(pos) => pos,
+        None => i64::try_from(ws.query_statuses_for_project(p.id)?.len()).unwrap_or(i64::MAX),
+    };
+    let id = new_id();
+    ws.apply(Operation::CreateStatus(CreateStatus {
+        id,
+        project_id: p.id,
+        name,
+        category,
+        color,
+        position,
+    }))?;
+    let created = resolve_status_by_id(ws, p.id, id)?;
+    if out.json {
+        out.print_json(&created)?;
+    } else {
+        println!(
+            "created {} ({}, {})",
+            created.name,
+            created.category.as_str(),
+            created.color
+        );
+    }
+    Ok(())
+}
+
+fn update(
+    ws: &mut Workspace,
+    out: &Out,
+    project: &str,
+    name: &str,
+    rename: Option<String>,
+    category: Option<String>,
+    color: Option<String>,
+) -> Result<()> {
+    let p = resolve_project(ws, project)?;
+    let status = resolve_status_in_project(ws, p.id, name)?;
+    if rename.is_none() && category.is_none() && color.is_none() {
+        return Err(kanban_core::Error::Validation(
+            kanban_core::ValidationError {
+                field: "fields".into(),
+                reason: "supply --rename, --category, or --color".into(),
+            },
+        ));
+    }
+    let category = category.map(|c| parse_category(&c)).transpose()?;
+    ws.apply(Operation::UpdateStatus(UpdateStatus {
+        id: status.id,
+        patch: StatusPatch {
+            name: rename,
+            category,
+            color,
+        },
+    }))?;
+    let updated = resolve_status_by_id(ws, p.id, status.id)?;
+    if out.json {
+        out.print_json(&updated)?;
+    } else {
+        println!("updated {}", updated.name);
+    }
+    Ok(())
+}
+
+fn delete(ws: &mut Workspace, out: &Out, project: &str, name: &str, yes: bool) -> Result<()> {
+    if !yes {
+        return Err(kanban_core::Error::Validation(
+            kanban_core::ValidationError {
+                field: "confirm".into(),
+                reason: "pass --yes to confirm deletion".into(),
+            },
+        ));
+    }
+    let p = resolve_project(ws, project)?;
+    let status = resolve_status_in_project(ws, p.id, name)?;
+    ws.apply(Operation::DeleteStatus(DeleteStatus { id: status.id }))?;
+    if !out.json {
+        println!("deleted {}", status.name);
+    }
+    Ok(())
+}
+
+fn reorder(ws: &mut Workspace, out: &Out, project: &str, name: &str, position: i64) -> Result<()> {
+    let p = resolve_project(ws, project)?;
+    let status = resolve_status_in_project(ws, p.id, name)?;
+    ws.apply(Operation::ReorderStatus(ReorderStatus {
+        id: status.id,
+        new_position: position,
+    }))?;
+    let statuses = ws.query_statuses_for_project(p.id)?;
+    if out.json {
+        out.print_json(&statuses)?;
+    } else {
+        for s in &statuses {
+            println!("{}  {}  {}", s.name, s.category.as_str(), s.color);
+        }
+    }
+    Ok(())
+}
+
+fn resolve_status_by_id(ws: &Workspace, project_id: Uuid, id: Uuid) -> Result<Status> {
+    ws.query_statuses_for_project(project_id)?
+        .into_iter()
+        .find(|s| s.id == id)
+        .ok_or(kanban_core::Error::NotFound {
+            kind: kanban_core::EntityKind::Status,
+            id: id.to_string(),
+        })
 }

--- a/crates/kanban-cli/src/main.rs
+++ b/crates/kanban-cli/src/main.rs
@@ -42,7 +42,7 @@ fn run(args: Cli) -> kanban_core::Result<()> {
         Cmd::Project(c) => cmd::project::run(c, &mut ws, &out),
         Cmd::Issue(c) => cmd::issue::run(c, &mut ws, &out),
         Cmd::Label(c) => cmd::label::run(c, &mut ws, &out),
-        Cmd::Status(c) => cmd::status::run(c, &ws, &out),
+        Cmd::Status(c) => cmd::status::run(c, &mut ws, &out),
         Cmd::Search(c) => cmd::search::run(c, &ws, &out),
         Cmd::Export(c) => cmd::export::run(c, &ws, &out),
         Cmd::Import(c) => cmd::import::run(c, &mut ws, &out),

--- a/crates/kanban-cli/tests/snapshots/status_cmds__status_list_with_review.snap
+++ b/crates/kanban-cli/tests/snapshots/status_cmds__status_list_with_review.snap
@@ -1,0 +1,12 @@
+---
+source: crates/kanban-cli/tests/status_cmds.rs
+expression: stdout
+---
+Todo  unstarted  #94a3b8
+Backlog  unstarted  #64748b
+In Progress  started  #3b82f6
+In Review  started  #a855f7
+Blocked  blocked  #ef4444
+Discarded  discarded  #6b7280
+Done  completed  #22c55e
+Review  started  #abcdef

--- a/crates/kanban-cli/tests/status_cmds.rs
+++ b/crates/kanban-cli/tests/status_cmds.rs
@@ -1,0 +1,319 @@
+//! Integration tests for `kanban status` write subcommands.
+
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::panic)]
+
+use assert_cmd::Command;
+use std::path::PathBuf;
+
+fn isolated_db() -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("data.db");
+    (dir, path)
+}
+
+fn cli(db: &PathBuf) -> Command {
+    let mut c = Command::cargo_bin("kanban").unwrap();
+    c.env("KANBAN_DB", db);
+    c
+}
+
+fn make_project(db: &PathBuf) {
+    cli(db)
+        .args(["project", "create", "P", "--prefix", "PRJ"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn status_create_then_list() {
+    let (_d, db) = isolated_db();
+    make_project(&db);
+    cli(&db)
+        .args([
+            "status",
+            "create",
+            "--project",
+            "PRJ",
+            "--name",
+            "Review",
+            "--category",
+            "started",
+            "--color",
+            "#abcdef",
+        ])
+        .assert()
+        .success();
+    let out = cli(&db)
+        .args(["status", "list", "--project", "PRJ"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    insta::assert_snapshot!("status_list_with_review", stdout);
+}
+
+#[test]
+fn status_create_duplicate_name_exits_validation() {
+    let (_d, db) = isolated_db();
+    make_project(&db);
+    cli(&db)
+        .args([
+            "status",
+            "create",
+            "--project",
+            "PRJ",
+            "--name",
+            "Review",
+            "--category",
+            "started",
+            "--color",
+            "#abcdef",
+        ])
+        .assert()
+        .success();
+    let assert = cli(&db)
+        .args([
+            "status",
+            "create",
+            "--project",
+            "PRJ",
+            "--name",
+            "Review",
+            "--category",
+            "started",
+            "--color",
+            "#123456",
+        ])
+        .assert()
+        .failure();
+    // Conflict/validation maps to EXIT_VALIDATION (3).
+    assert.code(3);
+}
+
+#[test]
+fn status_create_unknown_category_exits_validation() {
+    let (_d, db) = isolated_db();
+    make_project(&db);
+    let assert = cli(&db)
+        .args([
+            "status",
+            "create",
+            "--project",
+            "PRJ",
+            "--name",
+            "Review",
+            "--category",
+            "bogus",
+            "--color",
+            "#abcdef",
+        ])
+        .assert()
+        .failure();
+    assert.code(3);
+}
+
+#[test]
+fn status_update_rename() {
+    let (_d, db) = isolated_db();
+    make_project(&db);
+    cli(&db)
+        .args([
+            "status",
+            "create",
+            "--project",
+            "PRJ",
+            "--name",
+            "Review",
+            "--category",
+            "started",
+            "--color",
+            "#abcdef",
+        ])
+        .assert()
+        .success();
+    cli(&db)
+        .args([
+            "status",
+            "update",
+            "--project",
+            "PRJ",
+            "--name",
+            "Review",
+            "--rename",
+            "Reviewing",
+        ])
+        .assert()
+        .success();
+    let out = cli(&db)
+        .args(["--json", "status", "list", "--project", "PRJ"])
+        .output()
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let names: Vec<&str> = v
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s["name"].as_str().unwrap())
+        .collect();
+    assert!(names.contains(&"Reviewing"));
+    assert!(!names.contains(&"Review"));
+}
+
+#[test]
+fn status_delete_empty_succeeds() {
+    let (_d, db) = isolated_db();
+    make_project(&db);
+    cli(&db)
+        .args([
+            "status",
+            "create",
+            "--project",
+            "PRJ",
+            "--name",
+            "Review",
+            "--category",
+            "started",
+            "--color",
+            "#abcdef",
+        ])
+        .assert()
+        .success();
+    cli(&db)
+        .args([
+            "status",
+            "delete",
+            "--project",
+            "PRJ",
+            "--name",
+            "Review",
+            "--yes",
+        ])
+        .assert()
+        .success();
+    let out = cli(&db)
+        .args(["--json", "status", "list", "--project", "PRJ"])
+        .output()
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let names: Vec<&str> = v
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s["name"].as_str().unwrap())
+        .collect();
+    assert!(!names.contains(&"Review"));
+}
+
+#[test]
+fn status_delete_without_yes_exits_validation() {
+    let (_d, db) = isolated_db();
+    make_project(&db);
+    cli(&db)
+        .args([
+            "status",
+            "create",
+            "--project",
+            "PRJ",
+            "--name",
+            "Review",
+            "--category",
+            "started",
+            "--color",
+            "#abcdef",
+        ])
+        .assert()
+        .success();
+    let assert = cli(&db)
+        .args(["status", "delete", "--project", "PRJ", "--name", "Review"])
+        .assert()
+        .failure();
+    assert.code(3);
+}
+
+#[test]
+fn status_delete_with_issue_exits_conflict() {
+    let (_d, db) = isolated_db();
+    make_project(&db);
+    // Default project ships with statuses; find the default status an issue lands in.
+    // Create an issue (lands in the project's initial status), then move it into our
+    // new status so deletion is blocked.
+    cli(&db)
+        .args([
+            "status",
+            "create",
+            "--project",
+            "PRJ",
+            "--name",
+            "Review",
+            "--category",
+            "started",
+            "--color",
+            "#abcdef",
+        ])
+        .assert()
+        .success();
+    cli(&db)
+        .args(["issue", "create", "--project", "PRJ", "--title", "fix it"])
+        .assert()
+        .success();
+    cli(&db)
+        .args(["issue", "move", "PRJ-1", "--status", "Review"])
+        .assert()
+        .success();
+    let assert = cli(&db)
+        .args([
+            "status",
+            "delete",
+            "--project",
+            "PRJ",
+            "--name",
+            "Review",
+            "--yes",
+        ])
+        .assert()
+        .failure();
+    // Conflict maps to EXIT_VALIDATION (3).
+    assert.code(3);
+}
+
+#[test]
+fn status_reorder_changes_order() {
+    let (_d, db) = isolated_db();
+    make_project(&db);
+    cli(&db)
+        .args([
+            "status",
+            "create",
+            "--project",
+            "PRJ",
+            "--name",
+            "Review",
+            "--category",
+            "started",
+            "--color",
+            "#abcdef",
+        ])
+        .assert()
+        .success();
+    // Move the newly-appended status to the front.
+    cli(&db)
+        .args([
+            "status",
+            "reorder",
+            "--project",
+            "PRJ",
+            "--name",
+            "Review",
+            "--position",
+            "0",
+        ])
+        .assert()
+        .success();
+    let out = cli(&db)
+        .args(["--json", "status", "list", "--project", "PRJ"])
+        .output()
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let first = v.as_array().unwrap().first().unwrap();
+    assert_eq!(first["name"].as_str().unwrap(), "Review");
+}

--- a/crates/kanban-core/src/apply/mod.rs
+++ b/crates/kanban-core/src/apply/mod.rs
@@ -84,7 +84,8 @@ pub(crate) fn dispatch(
         Operation::DetachLabel(args) => labels::detach(tx, args)?,
         Operation::CreateStatus(args) => statuses::create(tx, args)?,
         Operation::UpdateStatus(args) => statuses::update(tx, args)?,
-        Operation::DeleteStatus(args) => statuses::delete_plain(tx, args)?,
+        Operation::DeleteStatus(args) => statuses::delete(tx, args)?,
+        Operation::ReorderStatus(args) => statuses::reorder(tx, args)?,
         Operation::ImportSnapshot(args) => snapshot::import(tx, args)?,
     }
     Ok(())
@@ -108,6 +109,7 @@ fn op_type_name(op: &Operation) -> &'static str {
         Operation::CreateStatus(_) => "CreateStatus",
         Operation::UpdateStatus(_) => "UpdateStatus",
         Operation::DeleteStatus(_) => "DeleteStatus",
+        Operation::ReorderStatus(_) => "ReorderStatus",
         Operation::ImportSnapshot(_) => "ImportSnapshot",
     }
 }
@@ -132,6 +134,7 @@ fn capture_inverse(tx: &rusqlite::Transaction<'_>, op: &Operation) -> Result<Ope
         Operation::CreateStatus(args) => Ok(statuses::inverse_of_create(args)),
         Operation::UpdateStatus(args) => statuses::inverse_of_update(tx, args),
         Operation::DeleteStatus(args) => statuses::inverse_of_delete(tx, args),
+        Operation::ReorderStatus(args) => statuses::inverse_of_reorder(tx, args),
         Operation::ImportSnapshot(args) => snapshot::inverse_of_import(tx, args),
     }
 }

--- a/crates/kanban-core/src/apply/mod.rs
+++ b/crates/kanban-core/src/apply/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod issues;
 pub(crate) mod labels;
 pub(crate) mod projects;
 pub(crate) mod snapshot;
+pub(crate) mod statuses;
 
 impl Workspace {
     /// The single public mutator. Validates, executes, and records `op` in one transaction.
@@ -81,6 +82,9 @@ pub(crate) fn dispatch(
         Operation::DeleteLabel(args) => labels::delete(tx, args)?,
         Operation::AttachLabel(args) => labels::attach(tx, args)?,
         Operation::DetachLabel(args) => labels::detach(tx, args)?,
+        Operation::CreateStatus(args) => statuses::create(tx, args)?,
+        Operation::UpdateStatus(args) => statuses::update(tx, args)?,
+        Operation::DeleteStatus(args) => statuses::delete_plain(tx, args)?,
         Operation::ImportSnapshot(args) => snapshot::import(tx, args)?,
     }
     Ok(())
@@ -101,6 +105,9 @@ fn op_type_name(op: &Operation) -> &'static str {
         Operation::DeleteLabel(_) => "DeleteLabel",
         Operation::AttachLabel(_) => "AttachLabel",
         Operation::DetachLabel(_) => "DetachLabel",
+        Operation::CreateStatus(_) => "CreateStatus",
+        Operation::UpdateStatus(_) => "UpdateStatus",
+        Operation::DeleteStatus(_) => "DeleteStatus",
         Operation::ImportSnapshot(_) => "ImportSnapshot",
     }
 }
@@ -122,6 +129,9 @@ fn capture_inverse(tx: &rusqlite::Transaction<'_>, op: &Operation) -> Result<Ope
         Operation::UpdateLabel(args) => labels::inverse_of_update(tx, args),
         Operation::AttachLabel(args) => Ok(labels::inverse_of_attach(args)),
         Operation::DetachLabel(args) => Ok(labels::inverse_of_detach(args)),
+        Operation::CreateStatus(args) => Ok(statuses::inverse_of_create(args)),
+        Operation::UpdateStatus(args) => statuses::inverse_of_update(tx, args),
+        Operation::DeleteStatus(args) => statuses::inverse_of_delete(tx, args),
         Operation::ImportSnapshot(args) => snapshot::inverse_of_import(tx, args),
     }
 }

--- a/crates/kanban-core/src/apply/snapshot.rs
+++ b/crates/kanban-core/src/apply/snapshot.rs
@@ -327,6 +327,28 @@ pub(crate) fn export_issue_subtree_via_tx(
     })
 }
 
+/// Capture a single status row as a one-element snapshot. Used to build the
+/// inverse of `DeleteStatus` so undo restores `category`/`color`/`position`
+/// and the original id — none of which a plain `CreateStatus` op would carry
+/// without re-deriving them. `snapshot::import` upserts `snapshot.statuses`.
+pub(crate) fn export_status_row(
+    tx: &Transaction<'_>,
+    status_id: uuid::Uuid,
+) -> Result<crate::snapshot::WorkspaceSnapshot> {
+    use crate::snapshot::{SNAPSHOT_SCHEMA_VERSION, WorkspaceSnapshot};
+
+    let status = crate::store::read::statuses::by_id_via_tx(tx, status_id)?;
+    Ok(WorkspaceSnapshot {
+        schema_version: SNAPSHOT_SCHEMA_VERSION,
+        exported_at: chrono::Utc::now(),
+        projects: Vec::new(),
+        statuses: vec![status],
+        labels: Vec::new(),
+        issues: Vec::new(),
+        issue_labels: Vec::new(),
+    })
+}
+
 /// Capture the label row + all `issue_labels` rows that reference it. Used to
 /// build the inverse of `DeleteLabel` so undo restores attachments that the
 /// CASCADE delete tore down.

--- a/crates/kanban-core/src/apply/snapshot.rs
+++ b/crates/kanban-core/src/apply/snapshot.rs
@@ -349,6 +349,27 @@ pub(crate) fn export_status_row(
     })
 }
 
+/// Capture all of a project's status rows as a snapshot (other entity arrays
+/// empty). Used to build the inverse of `ReorderStatus`: re-importing every
+/// status row under `Overwrite` restores all prior `position` values.
+pub(crate) fn export_project_statuses(
+    tx: &Transaction<'_>,
+    project_id: uuid::Uuid,
+) -> Result<crate::snapshot::WorkspaceSnapshot> {
+    use crate::snapshot::{SNAPSHOT_SCHEMA_VERSION, WorkspaceSnapshot};
+
+    let statuses = crate::store::read::statuses::for_project_via_tx(tx, project_id)?;
+    Ok(WorkspaceSnapshot {
+        schema_version: SNAPSHOT_SCHEMA_VERSION,
+        exported_at: chrono::Utc::now(),
+        projects: Vec::new(),
+        statuses,
+        labels: Vec::new(),
+        issues: Vec::new(),
+        issue_labels: Vec::new(),
+    })
+}
+
 /// Capture the label row + all `issue_labels` rows that reference it. Used to
 /// build the inverse of `DeleteLabel` so undo restores attachments that the
 /// CASCADE delete tore down.

--- a/crates/kanban-core/src/apply/statuses.rs
+++ b/crates/kanban-core/src/apply/statuses.rs
@@ -1,0 +1,84 @@
+use crate::error::{Error, Result};
+use crate::operation::{
+    ConflictPolicy, CreateStatus, DeleteStatus, ImportSnapshot, Operation, StatusPatch,
+    UpdateStatus,
+};
+use crate::store::write::statuses as ws;
+use crate::validate;
+use rusqlite::{Transaction, params};
+
+pub(crate) fn create(tx: &Transaction<'_>, args: &CreateStatus) -> Result<()> {
+    validate::nonempty_field("name", &args.name)?;
+    validate::hex_color(&args.color)?;
+    let exists: bool = tx.query_row(
+        "SELECT COUNT(*) FROM statuses WHERE project_id = ?1 AND name = ?2",
+        params![args.project_id.to_string(), &args.name],
+        |r| r.get::<_, i64>(0).map(|n| n > 0),
+    )?;
+    if exists {
+        return Err(Error::Conflict(format!(
+            "status '{}' already exists in project",
+            args.name
+        )));
+    }
+    ws::insert(
+        tx,
+        args.id,
+        args.project_id,
+        &args.name,
+        args.category,
+        &args.color,
+        args.position,
+    )?;
+    Ok(())
+}
+
+pub(crate) fn update(tx: &Transaction<'_>, args: &UpdateStatus) -> Result<()> {
+    if let Some(n) = &args.patch.name {
+        validate::nonempty_field("name", n)?;
+    }
+    if let Some(c) = &args.patch.color {
+        validate::hex_color(c)?;
+    }
+    ws::update_fields(
+        tx,
+        args.id,
+        args.patch.name.as_deref(),
+        args.patch.category,
+        args.patch.color.as_deref(),
+    )?;
+    Ok(())
+}
+
+/// Plain delete (no usage guards). Guards land in Task 2 alongside
+/// `ReorderStatus`.
+pub(crate) fn delete_plain(tx: &Transaction<'_>, args: &DeleteStatus) -> Result<()> {
+    ws::delete(tx, args.id)?;
+    Ok(())
+}
+
+pub(crate) fn inverse_of_create(args: &CreateStatus) -> Operation {
+    Operation::DeleteStatus(DeleteStatus { id: args.id })
+}
+
+pub(crate) fn inverse_of_update(tx: &Transaction<'_>, args: &UpdateStatus) -> Result<Operation> {
+    let s = crate::store::read::statuses::by_id_via_tx(tx, args.id)?;
+    Ok(Operation::UpdateStatus(UpdateStatus {
+        id: s.id,
+        patch: StatusPatch {
+            name: args.patch.name.as_ref().map(|_| s.name.clone()),
+            category: args.patch.category.as_ref().map(|_| s.category),
+            color: args.patch.color.as_ref().map(|_| s.color.clone()),
+        },
+    }))
+}
+
+/// Capture the inverse of `DeleteStatus` as an `ImportSnapshot` carrying the
+/// status row, so undo restores `id`/`category`/`color`/`position` exactly.
+pub(crate) fn inverse_of_delete(tx: &Transaction<'_>, args: &DeleteStatus) -> Result<Operation> {
+    let snapshot = crate::apply::snapshot::export_status_row(tx, args.id)?;
+    Ok(Operation::ImportSnapshot(ImportSnapshot {
+        snapshot,
+        policy: ConflictPolicy::Overwrite,
+    }))
+}

--- a/crates/kanban-core/src/apply/statuses.rs
+++ b/crates/kanban-core/src/apply/statuses.rs
@@ -1,7 +1,7 @@
 use crate::error::{Error, Result};
 use crate::operation::{
-    ConflictPolicy, CreateStatus, DeleteStatus, ImportSnapshot, Operation, StatusPatch,
-    UpdateStatus,
+    ConflictPolicy, CreateStatus, DeleteStatus, ImportSnapshot, Operation, ReorderStatus,
+    StatusPatch, UpdateStatus,
 };
 use crate::store::write::statuses as ws;
 use crate::validate;
@@ -50,10 +50,56 @@ pub(crate) fn update(tx: &Transaction<'_>, args: &UpdateStatus) -> Result<()> {
     Ok(())
 }
 
-/// Plain delete (no usage guards). Guards land in Task 2 alongside
-/// `ReorderStatus`.
-pub(crate) fn delete_plain(tx: &Transaction<'_>, args: &DeleteStatus) -> Result<()> {
-    ws::delete(tx, args.id)?;
+/// Delete a status, guarded so it cannot orphan issues or empty a project's
+/// status set. Both guards roll back the whole transaction on failure, so the
+/// inverse captured before dispatch is discarded.
+pub(crate) fn delete(tx: &Transaction<'_>, a: &DeleteStatus) -> Result<()> {
+    // status must exist (and we need its project_id) — by_id_via_tx errors NotFound if absent
+    let s = crate::store::read::statuses::by_id_via_tx(tx, a.id)?;
+    // guard 1: no issues may reference it
+    let issue_count: i64 = tx.query_row(
+        "SELECT COUNT(*) FROM issues WHERE status_id = ?1",
+        params![a.id.to_string()],
+        |r| r.get(0),
+    )?;
+    if issue_count > 0 {
+        return Err(Error::Conflict(format!(
+            "status still has {issue_count} issue(s); move or delete them first"
+        )));
+    }
+    // guard 2: a project must keep at least one status
+    let status_count: i64 = tx.query_row(
+        "SELECT COUNT(*) FROM statuses WHERE project_id = ?1",
+        params![s.project_id.to_string()],
+        |r| r.get(0),
+    )?;
+    if status_count <= 1 {
+        return Err(Error::Conflict(
+            "a project must keep at least one status".into(),
+        ));
+    }
+    ws::delete(tx, a.id)?;
+    Ok(())
+}
+
+/// Re-pack a project's status positions so that `a.id` lands at `new_position`.
+/// Positions are reassigned densely (`0..n`) so the order stays gap-free.
+pub(crate) fn reorder(tx: &Transaction<'_>, a: &ReorderStatus) -> Result<()> {
+    let target = crate::store::read::statuses::by_id_via_tx(tx, a.id)?;
+    // for_project_via_tx orders by position ASC.
+    let mut ordered = crate::store::read::statuses::for_project_via_tx(tx, target.project_id)?;
+    ordered.retain(|s| s.id != a.id);
+    // Clamp the requested position into `0..=ordered.len()`. `usize::try_from`
+    // maps any negative request to 0 (treated as "front").
+    let idx = usize::try_from(a.new_position.max(0))
+        .unwrap_or(0)
+        .min(ordered.len());
+    ordered.insert(idx, target);
+    for (pos, s) in ordered.iter().enumerate() {
+        // `pos` is a vector index, always well within i64 range.
+        let position = i64::try_from(pos).unwrap_or(i64::MAX);
+        ws::update_position(tx, s.id, position)?;
+    }
     Ok(())
 }
 
@@ -79,6 +125,16 @@ pub(crate) fn inverse_of_delete(tx: &Transaction<'_>, args: &DeleteStatus) -> Re
     let snapshot = crate::apply::snapshot::export_status_row(tx, args.id)?;
     Ok(Operation::ImportSnapshot(ImportSnapshot {
         snapshot,
+        policy: ConflictPolicy::Overwrite,
+    }))
+}
+
+/// Capture every status row of the affected project as an `ImportSnapshot`, so
+/// undo re-imports them under `Overwrite` and restores all prior positions.
+pub(crate) fn inverse_of_reorder(tx: &Transaction<'_>, a: &ReorderStatus) -> Result<Operation> {
+    let s = crate::store::read::statuses::by_id_via_tx(tx, a.id)?;
+    Ok(Operation::ImportSnapshot(ImportSnapshot {
+        snapshot: crate::apply::snapshot::export_project_statuses(tx, s.project_id)?,
         policy: ConflictPolicy::Overwrite,
     }))
 }

--- a/crates/kanban-core/src/operation.rs
+++ b/crates/kanban-core/src/operation.rs
@@ -22,6 +22,10 @@ pub enum Operation {
     AttachLabel(AttachLabel),
     DetachLabel(DetachLabel),
 
+    CreateStatus(CreateStatus),
+    UpdateStatus(UpdateStatus),
+    DeleteStatus(DeleteStatus),
+
     ImportSnapshot(ImportSnapshot),
 }
 
@@ -142,6 +146,36 @@ pub struct AttachLabel {
 pub struct DetachLabel {
     pub issue_id: Uuid,
     pub label_id: Uuid,
+}
+
+// ----- Status ops -----
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CreateStatus {
+    pub id: Uuid,
+    pub project_id: Uuid,
+    pub name: String,
+    pub category: crate::types::StatusCategory,
+    pub color: String,
+    pub position: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UpdateStatus {
+    pub id: Uuid,
+    pub patch: StatusPatch,
+}
+
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct StatusPatch {
+    pub name: Option<String>,
+    pub category: Option<crate::types::StatusCategory>,
+    pub color: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DeleteStatus {
+    pub id: Uuid,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/kanban-core/src/operation.rs
+++ b/crates/kanban-core/src/operation.rs
@@ -25,6 +25,7 @@ pub enum Operation {
     CreateStatus(CreateStatus),
     UpdateStatus(UpdateStatus),
     DeleteStatus(DeleteStatus),
+    ReorderStatus(ReorderStatus),
 
     ImportSnapshot(ImportSnapshot),
 }
@@ -176,6 +177,12 @@ pub struct StatusPatch {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DeleteStatus {
     pub id: Uuid,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReorderStatus {
+    pub id: Uuid,
+    pub new_position: i64,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/kanban-core/src/store/read/statuses.rs
+++ b/crates/kanban-core/src/store/read/statuses.rs
@@ -1,4 +1,4 @@
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::types::{Status, StatusCategory};
 use rusqlite::{Connection, params};
 use std::str::FromStr;
@@ -31,6 +31,21 @@ pub(crate) fn for_project_via_tx(
         out.push(r?);
     }
     Ok(out)
+}
+
+pub(crate) fn by_id_via_tx(tx: &rusqlite::Transaction<'_>, id: Uuid) -> Result<Status> {
+    tx.query_row(
+        "SELECT id,project_id,name,category,color,position FROM statuses WHERE id = ?1",
+        params![id.to_string()],
+        row_to_status,
+    )
+    .map_err(|e| match e {
+        rusqlite::Error::QueryReturnedNoRows => Error::NotFound {
+            kind: crate::EntityKind::Status,
+            id: id.to_string(),
+        },
+        other => other.into(),
+    })
 }
 
 fn row_to_status(r: &rusqlite::Row<'_>) -> rusqlite::Result<Status> {

--- a/crates/kanban-core/src/store/write/statuses.rs
+++ b/crates/kanban-core/src/store/write/statuses.rs
@@ -74,6 +74,14 @@ pub(crate) fn delete(tx: &Transaction<'_>, id: Uuid) -> Result<()> {
     Ok(())
 }
 
+pub(crate) fn update_position(tx: &Transaction<'_>, id: Uuid, position: i64) -> Result<()> {
+    tx.execute(
+        "UPDATE statuses SET position = ?1 WHERE id = ?2",
+        params![position, id.to_string()],
+    )?;
+    Ok(())
+}
+
 pub(crate) fn seed_defaults(tx: &Transaction<'_>, project_id: Uuid) -> Result<Vec<Uuid>> {
     let mut ids = Vec::with_capacity(DEFAULTS.len());
     for (name, category, color, position) in DEFAULTS {

--- a/crates/kanban-core/src/store/write/statuses.rs
+++ b/crates/kanban-core/src/store/write/statuses.rs
@@ -14,6 +14,66 @@ const DEFAULTS: &[(&str, StatusCategory, &str, i64)] = &[
     ("Done", StatusCategory::Completed, "#22c55e", 6),
 ];
 
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn insert(
+    tx: &Transaction<'_>,
+    id: Uuid,
+    project_id: Uuid,
+    name: &str,
+    category: StatusCategory,
+    color: &str,
+    position: i64,
+) -> Result<()> {
+    tx.execute(
+        "INSERT INTO statuses(id,project_id,name,category,color,position) VALUES (?1,?2,?3,?4,?5,?6)",
+        params![
+            id.to_string(),
+            project_id.to_string(),
+            name,
+            category.as_str(),
+            color,
+            position
+        ],
+    )?;
+    Ok(())
+}
+
+pub(crate) fn update_fields(
+    tx: &Transaction<'_>,
+    id: Uuid,
+    name: Option<&str>,
+    category: Option<StatusCategory>,
+    color: Option<&str>,
+) -> Result<()> {
+    if let Some(v) = name {
+        tx.execute(
+            "UPDATE statuses SET name = ?1 WHERE id = ?2",
+            params![v, id.to_string()],
+        )?;
+    }
+    if let Some(v) = category {
+        tx.execute(
+            "UPDATE statuses SET category = ?1 WHERE id = ?2",
+            params![v.as_str(), id.to_string()],
+        )?;
+    }
+    if let Some(v) = color {
+        tx.execute(
+            "UPDATE statuses SET color = ?1 WHERE id = ?2",
+            params![v, id.to_string()],
+        )?;
+    }
+    Ok(())
+}
+
+pub(crate) fn delete(tx: &Transaction<'_>, id: Uuid) -> Result<()> {
+    tx.execute(
+        "DELETE FROM statuses WHERE id = ?1",
+        params![id.to_string()],
+    )?;
+    Ok(())
+}
+
 pub(crate) fn seed_defaults(tx: &Transaction<'_>, project_id: Uuid) -> Result<Vec<Uuid>> {
     let mut ids = Vec::with_capacity(DEFAULTS.len());
     for (name, category, color, position) in DEFAULTS {

--- a/crates/kanban-core/tests/apply_statuses.rs
+++ b/crates/kanban-core/tests/apply_statuses.rs
@@ -2,9 +2,10 @@
 #![allow(clippy::panic)]
 
 use kanban_core::operation::{
-    CreateProject, CreateStatus, DeleteStatus, Operation, StatusPatch, UpdateStatus,
+    CreateIssue, CreateProject, CreateStatus, DeleteStatus, Operation, ReorderStatus, StatusPatch,
+    UpdateStatus,
 };
-use kanban_core::types::StatusCategory;
+use kanban_core::types::{Priority, StatusCategory};
 use kanban_core::{Workspace, new_id};
 
 fn fresh_with_project() -> (Workspace, uuid::Uuid) {
@@ -26,6 +27,13 @@ fn status_named(ws: &Workspace, pid: uuid::Uuid, name: &str) -> Option<kanban_co
         .unwrap()
         .into_iter()
         .find(|s| s.name == name)
+}
+
+/// The project's statuses ordered by `position` (the query already sorts ASC).
+fn ordered_statuses(ws: &Workspace, pid: uuid::Uuid) -> Vec<kanban_core::types::Status> {
+    let mut v = ws.query_statuses_for_project(pid).unwrap();
+    v.sort_by_key(|s| s.position);
+    v
 }
 
 #[test]
@@ -163,4 +171,110 @@ fn delete_status_undo_restores() {
     assert_eq!(s.id, id);
     assert_eq!(s.position, 7);
     assert_eq!(s.category, StatusCategory::Started);
+}
+
+#[test]
+fn delete_status_blocked_when_issues_present() {
+    let (mut ws, pid) = fresh_with_project();
+    // The seeded "Todo" status is one of the 7 defaults.
+    let todo = status_named(&ws, pid, "Todo").unwrap();
+    ws.apply(Operation::CreateIssue(CreateIssue {
+        id: new_id(),
+        project_id: pid,
+        title: "an issue".into(),
+        description: None,
+        status_id: todo.id,
+        priority: Priority::None,
+        due_date: None,
+        label_ids: vec![],
+    }))
+    .unwrap();
+
+    let err = ws
+        .apply(Operation::DeleteStatus(DeleteStatus { id: todo.id }))
+        .unwrap_err();
+    assert!(err.to_string().to_lowercase().contains("issue"), "{err}");
+    // The blocked delete must have rolled back: status still present.
+    assert!(status_named(&ws, pid, "Todo").is_some());
+}
+
+#[test]
+fn delete_status_blocked_when_last() {
+    let (mut ws, pid) = fresh_with_project();
+    // Delete defaults down to exactly one (each is empty), then the last errors.
+    let all = ordered_statuses(&ws, pid);
+    assert!(all.len() > 1, "project should seed multiple defaults");
+    for s in &all[1..] {
+        ws.apply(Operation::DeleteStatus(DeleteStatus { id: s.id }))
+            .unwrap();
+    }
+    let remaining = ordered_statuses(&ws, pid);
+    assert_eq!(remaining.len(), 1);
+
+    let err = ws
+        .apply(Operation::DeleteStatus(DeleteStatus {
+            id: remaining[0].id,
+        }))
+        .unwrap_err();
+    assert!(
+        err.to_string().to_lowercase().contains("at least one"),
+        "{err}"
+    );
+    // Rolled back: the last status survives.
+    assert_eq!(ordered_statuses(&ws, pid).len(), 1);
+}
+
+#[test]
+fn reorder_status_changes_order() {
+    let (mut ws, pid) = fresh_with_project();
+    let before = ordered_statuses(&ws, pid);
+    let last = before.last().unwrap().clone();
+    let first_before = before.first().unwrap().clone();
+
+    ws.apply(Operation::ReorderStatus(ReorderStatus {
+        id: last.id,
+        new_position: 0,
+    }))
+    .unwrap();
+
+    let after = ordered_statuses(&ws, pid);
+    assert_eq!(
+        after.first().unwrap().id,
+        last.id,
+        "moved status is now first"
+    );
+    assert_eq!(after[1].id, first_before.id, "old first shifted to index 1");
+    // positions remain dense 0..n
+    for (i, s) in after.iter().enumerate() {
+        assert_eq!(s.position, i64::try_from(i).unwrap());
+    }
+}
+
+#[test]
+fn reorder_status_undo_restores_order() {
+    let (mut ws, pid) = fresh_with_project();
+    let original_names: Vec<String> = ordered_statuses(&ws, pid)
+        .into_iter()
+        .map(|s| s.name)
+        .collect();
+    let last_id = ordered_statuses(&ws, pid).last().unwrap().id;
+
+    ws.apply(Operation::ReorderStatus(ReorderStatus {
+        id: last_id,
+        new_position: 0,
+    }))
+    .unwrap();
+    // sanity: order changed
+    let reordered_names: Vec<String> = ordered_statuses(&ws, pid)
+        .into_iter()
+        .map(|s| s.name)
+        .collect();
+    assert_ne!(reordered_names, original_names);
+
+    ws.undo().unwrap();
+    let restored_names: Vec<String> = ordered_statuses(&ws, pid)
+        .into_iter()
+        .map(|s| s.name)
+        .collect();
+    assert_eq!(restored_names, original_names);
 }

--- a/crates/kanban-core/tests/apply_statuses.rs
+++ b/crates/kanban-core/tests/apply_statuses.rs
@@ -1,0 +1,166 @@
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::panic)]
+
+use kanban_core::operation::{
+    CreateProject, CreateStatus, DeleteStatus, Operation, StatusPatch, UpdateStatus,
+};
+use kanban_core::types::StatusCategory;
+use kanban_core::{Workspace, new_id};
+
+fn fresh_with_project() -> (Workspace, uuid::Uuid) {
+    let mut ws = Workspace::open_in_memory().unwrap();
+    let pid = new_id();
+    ws.apply(Operation::CreateProject(CreateProject {
+        id: pid,
+        name: "S".into(),
+        prefix: "STS".into(),
+        description: None,
+        icon: None,
+    }))
+    .unwrap();
+    (ws, pid)
+}
+
+fn status_named(ws: &Workspace, pid: uuid::Uuid, name: &str) -> Option<kanban_core::types::Status> {
+    ws.query_statuses_for_project(pid)
+        .unwrap()
+        .into_iter()
+        .find(|s| s.name == name)
+}
+
+#[test]
+fn create_status_inserts() {
+    let (mut ws, pid) = fresh_with_project();
+    let id = new_id();
+    ws.apply(Operation::CreateStatus(CreateStatus {
+        id,
+        project_id: pid,
+        name: "QA".into(),
+        category: StatusCategory::Started,
+        color: "#3b82f6".into(),
+        position: 7,
+    }))
+    .unwrap();
+    let s = status_named(&ws, pid, "QA").unwrap();
+    assert_eq!(s.id, id);
+    assert_eq!(s.category, StatusCategory::Started);
+    assert_eq!(s.color, "#3b82f6");
+    assert_eq!(s.position, 7);
+}
+
+#[test]
+fn create_status_rejects_duplicate_name() {
+    let (mut ws, pid) = fresh_with_project();
+    ws.apply(Operation::CreateStatus(CreateStatus {
+        id: new_id(),
+        project_id: pid,
+        name: "QA".into(),
+        category: StatusCategory::Started,
+        color: "#3b82f6".into(),
+        position: 7,
+    }))
+    .unwrap();
+    let err = ws
+        .apply(Operation::CreateStatus(CreateStatus {
+            id: new_id(),
+            project_id: pid,
+            name: "QA".into(),
+            category: StatusCategory::Started,
+            color: "#3b82f6".into(),
+            position: 8,
+        }))
+        .unwrap_err();
+    assert!(err.to_string().to_lowercase().contains("conflict"), "{err}");
+}
+
+#[test]
+fn update_status_renames() {
+    let (mut ws, pid) = fresh_with_project();
+    let id = new_id();
+    ws.apply(Operation::CreateStatus(CreateStatus {
+        id,
+        project_id: pid,
+        name: "QA".into(),
+        category: StatusCategory::Started,
+        color: "#3b82f6".into(),
+        position: 7,
+    }))
+    .unwrap();
+    ws.apply(Operation::UpdateStatus(UpdateStatus {
+        id,
+        patch: StatusPatch {
+            name: Some("Testing".into()),
+            ..Default::default()
+        },
+    }))
+    .unwrap();
+    assert!(status_named(&ws, pid, "QA").is_none());
+    assert!(status_named(&ws, pid, "Testing").is_some());
+}
+
+#[test]
+fn create_status_undo_removes() {
+    let (mut ws, pid) = fresh_with_project();
+    let id = new_id();
+    ws.apply(Operation::CreateStatus(CreateStatus {
+        id,
+        project_id: pid,
+        name: "QA".into(),
+        category: StatusCategory::Started,
+        color: "#3b82f6".into(),
+        position: 7,
+    }))
+    .unwrap();
+    assert!(status_named(&ws, pid, "QA").is_some());
+    ws.undo().unwrap();
+    assert!(status_named(&ws, pid, "QA").is_none());
+}
+
+#[test]
+fn update_status_undo_restores_name() {
+    let (mut ws, pid) = fresh_with_project();
+    let id = new_id();
+    ws.apply(Operation::CreateStatus(CreateStatus {
+        id,
+        project_id: pid,
+        name: "QA".into(),
+        category: StatusCategory::Started,
+        color: "#3b82f6".into(),
+        position: 7,
+    }))
+    .unwrap();
+    ws.apply(Operation::UpdateStatus(UpdateStatus {
+        id,
+        patch: StatusPatch {
+            name: Some("Testing".into()),
+            ..Default::default()
+        },
+    }))
+    .unwrap();
+    ws.undo().unwrap();
+    assert!(status_named(&ws, pid, "Testing").is_none());
+    assert!(status_named(&ws, pid, "QA").is_some());
+}
+
+#[test]
+fn delete_status_undo_restores() {
+    let (mut ws, pid) = fresh_with_project();
+    let id = new_id();
+    ws.apply(Operation::CreateStatus(CreateStatus {
+        id,
+        project_id: pid,
+        name: "QA".into(),
+        category: StatusCategory::Started,
+        color: "#3b82f6".into(),
+        position: 7,
+    }))
+    .unwrap();
+    ws.apply(Operation::DeleteStatus(DeleteStatus { id }))
+        .unwrap();
+    assert!(status_named(&ws, pid, "QA").is_none());
+    ws.undo().unwrap();
+    let s = status_named(&ws, pid, "QA").unwrap();
+    assert_eq!(s.id, id);
+    assert_eq!(s.position, 7);
+    assert_eq!(s.category, StatusCategory::Started);
+}

--- a/docs/superpowers/plans/2026-06-06-kanban-v2-spec-5-custom-statuses-plan.md
+++ b/docs/superpowers/plans/2026-06-06-kanban-v2-spec-5-custom-statuses-plan.md
@@ -1,0 +1,79 @@
+# Kanban v2 — Spec #5 Custom Statuses Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]`.
+
+**Goal:** User-editable board columns — `CreateStatus`/`UpdateStatus`/`DeleteStatus`/`ReorderStatus` core operations (undoable), exposed in the GUI and CLI.
+
+**Architecture:** New write ops mirror the existing label ops: `operation.rs` (variants + structs), `apply/mod.rs` (dispatch/op_type_name/capture_inverse), new `apply/statuses.rs` (appliers + inverses), `store/write/statuses.rs` + `store/read/statuses.rs` additions, one `apply/snapshot.rs` helper. Tauri `apply` (generic) and MCP need no write changes. GUI adds `ops.ts` builders + board column management; CLI adds `status` write subcommands.
+
+**Tech:** Rust 2024 / rusqlite; React 19 / Vite / Tailwind (Spec #2 stack). TDD throughout.
+
+**Spec:** `docs/superpowers/specs/2026-06-06-kanban-v2-spec-5-custom-statuses-design.md`
+
+## Conventions
+- Rust via `~/.cargo/bin/cargo`. UI via `cd ui && PATH="/opt/homebrew/bin:$PATH" npx --yes pnpm@9.12.0 <script>` (if `build` fails on `@rollup/rollup-darwin-arm64`, run `… pnpm@9.12.0 install --force`). CONFIRM each gate's REAL exit code (`cmd; echo EXIT=$?`); never trust a piped grep/tail.
+- Gates: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`; ui `typecheck`/`lint`/`test:unit`/`build`. No `Co-Authored-By`. Copy clippy-allow headers from existing test files (`tests/apply_labels.rs`).
+- Core `Operation` enum is `#[serde(tag="op", content="args")]`. `StatusCategory` (`unstarted|started|blocked|completed|discarded`) has `as_str()`. `validate::nonempty_field`, `validate::hex_color`, `Error::{Validation,NotFound{kind:EntityKind::Status,id},Conflict(String)}`, `ConflictPolicy::Overwrite`, `Workspace::open_in_memory`, `new_id` all exist. `apply/snapshot.rs::import` already upserts `snapshot.statuses`.
+
+---
+
+### Task 1: Core — `CreateStatus` + `UpdateStatus` (test-first)
+
+**Files:** `crates/kanban-core/src/operation.rs`, `src/apply/mod.rs`, new `src/apply/statuses.rs`, `src/store/write/statuses.rs`, `src/store/read/statuses.rs`, new `tests/apply_statuses.rs`.
+
+- `operation.rs`: add enum variants `CreateStatus(CreateStatus)`, `UpdateStatus(UpdateStatus)` (also declare `DeleteStatus`/`ReorderStatus` variants now to keep the enum stable, even though their appliers land in Task 2 — OR add all four in Task 1 and implement appliers incrementally; pick one and keep `cargo build` green). Structs: `CreateStatus{ id:Uuid, project_id:Uuid, name:String, category:StatusCategory, color:String, position:i64 }`, `UpdateStatus{ id:Uuid, patch:StatusPatch }`, `StatusPatch{ name:Option<String>, category:Option<StatusCategory>, color:Option<String> }` (derive `Default`). Use `crate::types::StatusCategory`.
+- `store/read/statuses.rs`: add `pub(crate) fn by_id_via_tx(tx, id) -> Result<Status>` (reuse `row_to_status`; `QueryReturnedNoRows -> Error::NotFound{kind:EntityKind::Status,...}`).
+- `store/write/statuses.rs`: add `insert(tx,id,project_id,name,category,color,position)`, `update_fields(tx,id,name:Option<&str>,category:Option<StatusCategory>,color:Option<&str>)` (one UPDATE per Some field).
+- `apply/statuses.rs` (new): `create` (validate name+color, reject duplicate `(project_id,name)` with `Error::Conflict`, then `write::statuses::insert`), `update` (validate touched fields, `write::statuses::update_fields`), `inverse_of_create(args) -> DeleteStatus{id}`, `inverse_of_update(tx,args)` (read current via `by_id_via_tx`, build a `StatusPatch` echoing the prior values of the touched fields).
+- `apply/mod.rs`: `pub(crate) mod statuses;`; add `CreateStatus`/`UpdateStatus` arms to `dispatch`, `op_type_name`, `capture_inverse`.
+- `tests/apply_statuses.rs`: create-inserts; create-rejects-duplicate-name; update-renames; create-undo-removes; update-undo-restores-name. (apply→assert→undo→assert-restored.)
+
+- [ ] Write failing tests → implement → `cargo test -p kanban-core`, `clippy`, `fmt` green. Commit `feat(core): add CreateStatus and UpdateStatus operations`.
+
+### Task 2: Core — `DeleteStatus` (guarded) + `ReorderStatus` (test-first)
+
+**Files:** `apply/statuses.rs`, `store/write/statuses.rs`, `apply/snapshot.rs`, `apply/mod.rs`, `tests/apply_statuses.rs`.
+
+- `store/write/statuses.rs`: add `delete(tx,id)` and `update_position(tx,id,pos)`.
+- `apply/snapshot.rs`: add `pub(crate) fn export_status_row(tx, status_id) -> Result<WorkspaceSnapshot>` (a snapshot with just that one status) and `pub(crate) fn export_project_statuses(tx, project_id) -> Result<WorkspaceSnapshot>` (all of a project's statuses). Both use `WorkspaceSnapshot{ schema_version:SNAPSHOT_SCHEMA_VERSION, exported_at:Utc::now(), projects:vec![], statuses, issues:vec![], labels:vec![], issue_labels:vec![] }`.
+- `apply/statuses.rs`:
+  - `delete(tx,args)`: read the status (`by_id_via_tx`) for its `project_id`; guard 1 — `SELECT COUNT(*) FROM issues WHERE status_id=?` > 0 → `Error::Conflict("status still has N issue(s); move or delete them first")`; guard 2 — `SELECT COUNT(*) FROM statuses WHERE project_id=?` <= 1 → `Error::Conflict("a project must keep at least one status")`; else `write::statuses::delete`.
+  - `inverse_of_delete(tx,args)`: `ImportSnapshot{ snapshot: export_status_row(tx, args.id)?, policy: Overwrite }` (captured pre-delete — `capture_inverse` runs before `dispatch`).
+  - `reorder(tx,args)`: read status; load project statuses ordered by position (`read::statuses::for_project_via_tx`); remove the target, clamp `new_position` into `0..=len`, insert at that index, then `update_position` for every status to its new index `0..n-1`.
+  - `inverse_of_reorder(tx,args)`: `ImportSnapshot{ snapshot: export_project_statuses(tx, project_id)?, policy: Overwrite }` (captures all prior positions).
+- `apply/mod.rs`: add `DeleteStatus`/`ReorderStatus` arms to `dispatch`, `op_type_name`, `capture_inverse`.
+- `tests/apply_statuses.rs`: delete-empty-undo-restores; delete-blocked-when-issues-present (create issue in the status → Conflict); delete-blocked-when-last (single status → Conflict); reorder-changes-order; reorder-undo-restores-order (3 columns, move, undo, assert original order).
+
+- [ ] Write failing tests → implement → `cargo test --workspace`, `clippy`, `fmt` green. Commit `feat(core): add DeleteStatus (guarded) and ReorderStatus operations`.
+
+### Task 3: GUI — status op builders + board column management (test-first)
+
+**Files:** `ui/src/data/ops.ts` (+ test), board components (`ui/src/components/board/BoardColumn.tsx` + a new `ColumnMenu`/`AddColumn`), `ui/src/data/mutations.ts` (verify `qk.statuses(prefix)` invalidation on status ops), tests.
+
+- `ops.ts`: `createStatus({id,project_id,name,category,color,position})`, `updateStatus({id,name?,category?,color?})` (→ `{op:"UpdateStatus",args:{id,patch:{…}}}`), `deleteStatus({id})`, `reorderStatus({id,new_position})`. Verify shapes vs `operation.rs`. Tests.
+- `mutations.ts`: ensure `invalidateFor` invalidates `qk.statuses(prefix)` for `Create/Update/Delete/ReorderStatus` (and `qk.issues(prefix)` since a status delete/move can affect the board). Add the branch if missing.
+- Board: `BoardColumn` header gains a small menu — **Rename** (inline input → `updateStatus({id,name})`), **Recolor** (color input → `updateStatus({id,color})`), **Delete** (→ `deleteStatus({id})`; the button shows a toast/inline error when the apply rejects — non-empty or last). **Move left/right** buttons → `reorderStatus({id,new_position: currentIndex∓1})`. An **"+ Add column"** affordance at the board end → a small form (name + category select from the 5 values + color) → `createStatus({ id:uuidv7(), project_id, name, category, color, position: columns.length })`.
+- Tests (Vitest+RTL): builders; the column menu dispatches the right ops (rename/recolor/delete/move); add-column dispatches `CreateStatus`. Mock `useApply`. No `any`.
+
+- [ ] Test-first → implement → ui `typecheck`/`lint`/`test:unit`/`build` green (confirm EXIT=0). Commit `feat(ui): add, rename, recolor, reorder and delete board columns`.
+
+### Task 4: CLI — `status` write subcommands (test-first)
+
+**Files:** `crates/kanban-cli/src/cmd/status.rs`, snapshot tests.
+
+- Extend `StatusSub` with `Create{project,name,category,color,position?}`, `Update{id,name?,category?,color?}`, `Delete{id}`, `Reorder{id,position}` (mirror `cmd/label.rs`). A `parse_category(&str)->Result<StatusCategory>` helper. Each resolves the project (for Create), builds the op, calls `ws.apply`, prints the result (reuse the list/table formatting).
+- `insta` snapshots: create happy-path + a duplicate-name error; delete happy + blocked (non-empty) error.
+
+- [ ] Test-first → `cargo test --workspace` green. Commit `feat(cli): add status create/update/delete/reorder subcommands`.
+
+### Task 5: Acceptance + docs + PR
+
+- [ ] Full gates: `cargo fmt/clippy/test --workspace`; ui `typecheck/lint/test:unit/build`; bindings drift clean.
+- [ ] Update README/CLAUDE/DEVELOPMENT to note custom statuses (and that members/assignees remain Spec #6).
+- [ ] Commit; superpowers:finishing-a-development-branch → PR to `dev`.
+
+## Self-review notes
+- All four ops are undoable: Create→Delete, Update→Update(prior), Delete→ImportSnapshot(row), Reorder→ImportSnapshot(project statuses). `capture_inverse` runs before `dispatch`, so delete/reorder inverses capture pre-state.
+- Guards live in the applier (`dispatch`), so a blocked delete rolls back the whole transaction (inverse already captured is discarded). Block-until-empty + keep-≥1 per the design decision.
+- No migration; no DTO change (StatusDto already exists) → no bindings regen expected (verify the drift guard stays clean).
+- Verify every op struct's field set against `operation.rs` before building `ops.ts` builders / CLI args.

--- a/docs/superpowers/specs/2026-06-06-kanban-v2-spec-5-custom-statuses-design.md
+++ b/docs/superpowers/specs/2026-06-06-kanban-v2-spec-5-custom-statuses-design.md
@@ -1,0 +1,45 @@
+# Spec #5 — Custom Statuses
+
+**Date:** 2026-06-06
+**Builds on:** Spec #1 (core + CLI), Spec #2 (GUI), Spec #3 (MCP), Spec #4 (GUI completeness)
+**Roadmap:** E11 Custom Statuses — let users add / rename / recolor / reorder / delete the board's status columns.
+
+## Goal
+
+Make the board's columns user-editable. Today the 7 default statuses are seeded at project creation and are immutable (no status `Operation` exists). This spec adds four core operations — `CreateStatus`, `UpdateStatus`, `DeleteStatus`, `ReorderStatus` — fully undoable, then exposes them in the GUI (board column management) and the CLI. The Tauri `apply` command and the MCP server need no changes for writes (both go through `Workspace::apply`).
+
+## Decisions
+
+- **Delete is guarded (block-until-empty).** `DeleteStatus` refuses (`Error::Conflict`) if the status still has issues — the user must move/delete them first. It also refuses if it is the project's **last** status (a project always has ≥1 column). Fully recoverable via undo (the status row is captured in the inverse before removal).
+- **No migration.** The `statuses` table (`id, project_id, name, category, color, position`, `UNIQUE(project_id,name)`) already exists. `category` stays one of `unstarted|started|blocked|completed|discarded`.
+- **Reorder re-packs integer positions.** `ReorderStatus { id, new_position }` moves the status to the target index and renumbers the project's columns `0..n-1` in one transaction. Its inverse is an `ImportSnapshot` of the project's statuses captured *before* the move (restores every column's prior position exactly) — `snapshot::import` already upserts statuses.
+
+## Architecture (mirrors the existing label ops)
+
+Core `Operation` is `#[serde(tag="op", content="args")]`, so the GUI/CLI/MCP all build `{op, args}` and `Workspace::apply` dispatches. New variants flow through the same machinery: `apply/mod.rs` (`dispatch`, `op_type_name`, `capture_inverse`), a new `apply/statuses.rs` (appliers + `inverse_of_*`), additions to `store/write/statuses.rs` (`insert`/`delete`/`update_fields`/`update_position`) and `store/read/statuses.rs` (`by_id_via_tx`), and one snapshot helper for the delete/reorder inverses. Undo/redo, the operation log, and activity come for free.
+
+### Operations
+- `CreateStatus { id, project_id, name, category, color, position }` — validate (non-empty name, hex color, unique `(project_id,name)`); inverse `DeleteStatus{id}`.
+- `UpdateStatus { id, patch: StatusPatch{ name?, category?, color? } }` — rename/recategorize/recolor; inverse re-applies the prior values for the touched fields.
+- `DeleteStatus { id }` — guarded (no issues, not the last); inverse `ImportSnapshot` of the captured row.
+- `ReorderStatus { id, new_position }` — re-pack; inverse `ImportSnapshot` of the project's prior status ordering.
+
+### GUI (board)
+`ui/src/data/ops.ts` gains `createStatus`/`updateStatus`/`deleteStatus`/`reorderStatus` builders. The board (`BoardColumn` header) gets: a per-column menu (rename, recolor, delete — delete disabled/blocked with a toast if non-empty or last) and an "+ Add column" affordance; reorder via left/right move buttons (or drag — buttons are simpler and testable). Category is chosen from the five fixed values when adding/editing. Writes go through `useApply`; `invalidateFor` already invalidates `qk.statuses(prefix)` (verify) so the board refetches.
+
+### CLI
+`kanban status` gains `create`/`update`/`delete`/`reorder` subcommands (mirroring `kanban label`), each building the op and calling `apply`, with happy-path + error snapshots.
+
+## Non-goals / deferred
+- MCP status-management tools (the MCP server targets issue workflows; status setup via GUI/CLI suffices) — note for a later spec.
+- Drag-and-drop column reordering (buttons first).
+- Members/assignees — **Spec #6** (needs a migration).
+
+## Testing
+- Core: `tests/apply_statuses.rs` — create / duplicate-name conflict / update-rename / delete-undo-restores / delete-blocked-when-nonempty / delete-blocked-when-last / reorder-changes-order / reorder-undo-restores-order. Each follows the apply→assert→undo→assert-restored cycle.
+- CLI: `insta` snapshots (happy + error) via `assert_cmd`.
+- GUI: Vitest + RTL for the ops builders and the board column management component(s).
+- All gates green: `cargo fmt/clippy/test --workspace`; ui `typecheck/lint/test:unit/build`; bindings drift clean (no DTO change expected — statuses already have a DTO).
+
+## Acceptance
+A user can, from the GUI or CLI: add a new column (name + category + color), rename/recolor it, reorder columns, and delete an empty column (blocked with a clear message if it still holds issues or is the last column) — every change undoable.

--- a/ui/src/components/board/Board.tsx
+++ b/ui/src/components/board/Board.tsx
@@ -2,10 +2,13 @@ import { useMemo, useState } from "react";
 import { DndContext, type DragEndEvent, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
 import { useIssues, useStatuses } from "@/data/queries";
 import { useApply } from "@/data/mutations";
-import { ops, change } from "@/data/ops";
+import { ops, change, STATUS_CATEGORIES } from "@/data/ops";
 import { midpoint } from "@/lib/sortKey";
+import { uuidv7 } from "@/lib/uuid";
 import { BoardColumn } from "./BoardColumn";
 import { NewIssueInline } from "./NewIssueInline";
+
+const DEFAULT_COLUMN_COLOR = "#94a3b8";
 
 export function Board({ projectPrefix, projectId }: { projectPrefix: string; projectId: string }) {
   const { data: issues = [] } = useIssues(projectPrefix);
@@ -13,6 +16,10 @@ export function Board({ projectPrefix, projectId }: { projectPrefix: string; pro
   const apply = useApply(projectPrefix);
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }));
   const [addingStatus, setAddingStatus] = useState<string | null>(null);
+  const [addingColumn, setAddingColumn] = useState(false);
+  const [newColumnName, setNewColumnName] = useState("");
+  const [newColumnCategory, setNewColumnCategory] = useState<string>(STATUS_CATEGORIES[0]);
+  const [newColumnColor, setNewColumnColor] = useState(DEFAULT_COLUMN_COLOR);
 
   const columns = useMemo(
     () =>
@@ -51,19 +58,104 @@ export function Board({ projectPrefix, projectId }: { projectPrefix: string; pro
     apply.mutate(ops.reorderIssue({ id: dragged.id, new_sort_key: midpoint(before, after) }));
   }
 
+  function addColumn() {
+    const name = newColumnName.trim();
+    if (!name) return;
+    apply.mutate(
+      ops.createStatus({
+        id: uuidv7(),
+        project_id: projectId,
+        name,
+        category: newColumnCategory,
+        color: newColumnColor,
+        position: columns.length,
+      }),
+    );
+    setNewColumnName("");
+    setNewColumnCategory(STATUS_CATEGORIES[0]);
+    setNewColumnColor(DEFAULT_COLUMN_COLOR);
+    setAddingColumn(false);
+  }
+
   return (
     <div className="flex h-full flex-col">
       <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
         <div className="flex h-full gap-3 overflow-x-auto p-4">
-          {columns.map(({ status, issues: colIssues }) => (
+          {columns.map(({ status, issues: colIssues }, i) => (
             <BoardColumn
               key={status.id}
               status={status}
               issues={colIssues}
               projectPrefix={projectPrefix}
               onAddIssue={() => setAddingStatus(status.id)}
+              index={i}
+              count={columns.length}
             />
           ))}
+          <div className="w-[260px] shrink-0">
+            {addingColumn ? (
+              <form
+                className="flex flex-col gap-2 rounded-lg border border-dashed border-black/15 p-2.5 dark:border-white/15"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  addColumn();
+                }}
+              >
+                <input
+                  aria-label="New column name"
+                  autoFocus
+                  value={newColumnName}
+                  onChange={(e) => setNewColumnName(e.target.value)}
+                  placeholder="Column name"
+                  className="rounded border border-black/15 bg-transparent px-2 py-1 text-sm dark:border-white/15"
+                />
+                <div className="flex items-center gap-2">
+                  <select
+                    aria-label="New column category"
+                    value={newColumnCategory}
+                    onChange={(e) => setNewColumnCategory(e.target.value)}
+                    className="flex-1 rounded border border-black/15 bg-transparent px-1 py-1 text-xs dark:border-white/15"
+                  >
+                    {STATUS_CATEGORIES.map((c) => (
+                      <option key={c} value={c}>
+                        {c}
+                      </option>
+                    ))}
+                  </select>
+                  <input
+                    type="color"
+                    aria-label="New column color"
+                    value={newColumnColor}
+                    onChange={(e) => setNewColumnColor(e.target.value)}
+                    className="h-7 w-9 cursor-pointer border-0 bg-transparent p-0"
+                  />
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    type="submit"
+                    className="rounded-md bg-black/80 px-2 py-1 text-xs text-white hover:bg-black dark:bg-white/80 dark:text-black dark:hover:bg-white"
+                  >
+                    Add
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setAddingColumn(false)}
+                    className="rounded-md px-2 py-1 text-xs text-neutral-600 hover:bg-black/5 dark:text-neutral-300 dark:hover:bg-white/10"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </form>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setAddingColumn(true)}
+                className="w-full rounded-lg border border-dashed border-black/15 px-2 py-2 text-xs text-neutral-600 hover:bg-black/5 dark:border-white/15 dark:text-neutral-300 dark:hover:bg-white/10"
+              >
+                + Add column
+              </button>
+            )}
+          </div>
         </div>
       </DndContext>
       {addingStatus && (

--- a/ui/src/components/board/BoardColumn.tsx
+++ b/ui/src/components/board/BoardColumn.tsx
@@ -1,24 +1,142 @@
+import { useState } from "react";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import type { IssueDto, StatusDto } from "@/data/bindings";
+import { useApply } from "@/data/mutations";
+import { ops } from "@/data/ops";
 import { IssueCard } from "./IssueCard";
+
+/** Narrow an unknown error to its `message` string, if present. */
+function messageOf(e: unknown): string | undefined {
+  if (typeof e === "object" && e !== null && "message" in e) {
+    const m = (e as { message: unknown }).message;
+    if (typeof m === "string") return m;
+  }
+  return undefined;
+}
 
 export function BoardColumn({
   status,
   issues,
   projectPrefix,
   onAddIssue,
+  index,
+  count,
 }: {
   status: StatusDto;
   issues: IssueDto[];
   projectPrefix: string;
   onAddIssue: (statusId: string) => void;
+  index: number;
+  count: number;
 }) {
+  const apply = useApply(projectPrefix);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [renaming, setRenaming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function commitRename(value: string) {
+    setRenaming(false);
+    const name = value.trim();
+    if (name && name !== status.name) {
+      apply.mutate(ops.updateStatus({ id: status.id, name }));
+    }
+  }
+
   return (
     <div className="flex w-[260px] shrink-0 flex-col gap-2 rounded-lg bg-black/[0.03] p-2.5 dark:bg-white/[0.04]">
       <div className="flex items-center justify-between px-1">
-        <span className="text-sm font-semibold">{status.name}</span>
-        <span className="text-xs text-neutral-500">{issues.length}</span>
+        {renaming ? (
+          <input
+            aria-label="Rename column"
+            defaultValue={status.name}
+            autoFocus
+            className="w-full rounded border border-black/15 bg-transparent px-1 text-sm font-semibold dark:border-white/15"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") commitRename(e.currentTarget.value);
+              else if (e.key === "Escape") setRenaming(false);
+            }}
+            onBlur={(e) => commitRename(e.currentTarget.value)}
+          />
+        ) : (
+          <span className="text-sm font-semibold">{status.name}</span>
+        )}
+        <div className="flex items-center gap-1">
+          <span className="text-xs text-neutral-500">{issues.length}</span>
+          <div className="relative">
+            <button
+              type="button"
+              aria-label={`Column actions for ${status.name}`}
+              aria-expanded={menuOpen}
+              onClick={() => setMenuOpen((o) => !o)}
+              className="rounded px-1 text-sm text-neutral-500 hover:bg-black/5 dark:hover:bg-white/10"
+            >
+              ⋯
+            </button>
+            {menuOpen && (
+              <div className="absolute right-0 z-10 mt-1 flex w-44 flex-col gap-1 rounded-md border border-black/10 bg-white p-1 shadow-lg dark:border-white/10 dark:bg-neutral-800">
+                <button
+                  type="button"
+                  className="rounded px-2 py-1 text-left text-xs hover:bg-black/5 dark:hover:bg-white/10"
+                  onClick={() => {
+                    setRenaming(true);
+                    setMenuOpen(false);
+                  }}
+                >
+                  Rename
+                </button>
+                <label className="flex cursor-pointer items-center justify-between rounded px-2 py-1 text-xs hover:bg-black/5 dark:hover:bg-white/10">
+                  Color
+                  <input
+                    type="color"
+                    aria-label="Column color"
+                    value={status.color}
+                    onChange={(e) =>
+                      apply.mutate(ops.updateStatus({ id: status.id, color: e.target.value }))
+                    }
+                    className="h-4 w-6 cursor-pointer border-0 bg-transparent p-0"
+                  />
+                </label>
+                <button
+                  type="button"
+                  aria-label="Move column left"
+                  disabled={index === 0}
+                  className="rounded px-2 py-1 text-left text-xs hover:bg-black/5 disabled:opacity-40 dark:hover:bg-white/10"
+                  onClick={() =>
+                    apply.mutate(ops.reorderStatus({ id: status.id, new_position: index - 1 }))
+                  }
+                >
+                  Move left
+                </button>
+                <button
+                  type="button"
+                  aria-label="Move column right"
+                  disabled={index === count - 1}
+                  className="rounded px-2 py-1 text-left text-xs hover:bg-black/5 disabled:opacity-40 dark:hover:bg-white/10"
+                  onClick={() =>
+                    apply.mutate(ops.reorderStatus({ id: status.id, new_position: index + 1 }))
+                  }
+                >
+                  Move right
+                </button>
+                <button
+                  type="button"
+                  className="rounded px-2 py-1 text-left text-xs text-red-600 hover:bg-black/5 dark:text-red-400 dark:hover:bg-white/10"
+                  onClick={() => {
+                    setError(null);
+                    apply.mutate(ops.deleteStatus({ id: status.id }), {
+                      onError: (e) => setError(messageOf(e) ?? "Can't delete this column"),
+                      onSuccess: () => setMenuOpen(false),
+                    });
+                  }}
+                >
+                  Delete
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
       </div>
+      {error && <p className="px-1 text-xs text-red-500">{error}</p>}
       <SortableContext items={issues.map((i) => i.id)} strategy={verticalListSortingStrategy}>
         {issues.map((issue) => (
           <IssueCard key={issue.id} projectPrefix={projectPrefix} issue={issue} />

--- a/ui/src/data/mutations.ts
+++ b/ui/src/data/mutations.ts
@@ -68,6 +68,12 @@ function invalidateFor(qc: QueryClient, op: Operation, prefix?: string): void {
     }
     void qc.invalidateQueries({ queryKey: ["issues"] }); // detail panel chips
   }
+  if (["CreateStatus", "UpdateStatus", "DeleteStatus", "ReorderStatus"].includes(tag)) {
+    if (prefix) {
+      void qc.invalidateQueries({ queryKey: qk.statuses(prefix) });
+      void qc.invalidateQueries({ queryKey: qk.issues(prefix) });
+    }
+  }
   if (tag === "ImportSnapshot") void qc.invalidateQueries();
 }
 

--- a/ui/src/data/ops.ts
+++ b/ui/src/data/ops.ts
@@ -11,6 +11,16 @@
 export const PRIORITIES = ["none", "low", "medium", "high", "urgent"] as const;
 export type Priority = (typeof PRIORITIES)[number];
 
+/** Status categories, matching core's `StatusCategory` (lowercase serde). */
+export const STATUS_CATEGORIES = [
+  "unstarted",
+  "started",
+  "blocked",
+  "completed",
+  "discarded",
+] as const;
+export type StatusCategory = (typeof STATUS_CATEGORIES)[number];
+
 export type IssueFieldChange =
   | { field: "Title"; value: string }
   | { field: "Description"; value: string | null }
@@ -107,6 +117,35 @@ export const ops = {
     if (args.description !== undefined) patch.description = args.description;
     return { op: "UpdateProject", args: { id: args.id, patch } };
   },
+
+  createStatus: (args: {
+    id: string;
+    project_id: string;
+    name: string;
+    category: string;
+    color: string;
+    position: number;
+  }): Operation => ({ op: "CreateStatus", args }),
+
+  updateStatus: (args: {
+    id: string;
+    name?: string;
+    category?: string;
+    color?: string;
+  }): Operation => {
+    const patch: Record<string, unknown> = {};
+    if (args.name !== undefined) patch.name = args.name;
+    if (args.category !== undefined) patch.category = args.category;
+    if (args.color !== undefined) patch.color = args.color;
+    return { op: "UpdateStatus", args: { id: args.id, patch } };
+  },
+
+  deleteStatus: (args: { id: string }): Operation => ({ op: "DeleteStatus", args }),
+
+  reorderStatus: (args: { id: string; new_position: number }): Operation => ({
+    op: "ReorderStatus",
+    args,
+  }),
 
   archiveProject: (args: { id: string }): Operation => ({ op: "ArchiveProject", args }),
 

--- a/ui/tests/components/board/Board.test.tsx
+++ b/ui/tests/components/board/Board.test.tsx
@@ -1,8 +1,8 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/data/queries", () => ({
   useIssues: () => ({
@@ -15,16 +15,21 @@ vi.mock("@/data/queries", () => ({
   }),
   useStatuses: () => ({
     data: [
-      { id: "s1", name: "To Do", position: 1 },
-      { id: "s2", name: "In Progress", position: 2 },
+      { id: "s1", name: "To Do", category: "unstarted", color: "#94a3b8", position: 1 },
+      { id: "s2", name: "In Progress", category: "started", color: "#3b82f6", position: 2 },
     ],
     isLoading: false,
     isError: false,
   }),
 }));
-vi.mock("@/data/mutations", () => ({ useApply: () => ({ mutate: vi.fn(), isPending: false }) }));
+const mutateMock = vi.hoisted(() => vi.fn());
+vi.mock("@/data/mutations", () => ({ useApply: () => ({ mutate: mutateMock, isPending: false }) }));
 
 import { Board } from "@/components/board/Board";
+
+beforeEach(() => {
+  mutateMock.mockReset();
+});
 
 function wrapper({ children }: { children: ReactNode }) {
   return (
@@ -41,5 +46,27 @@ describe("Board", () => {
     expect(screen.getByText("In Progress")).toBeInTheDocument();
     expect(screen.getByText("First")).toBeInTheDocument();
     expect(screen.getByText("Second")).toBeInTheDocument();
+  });
+
+  it("add-column form dispatches CreateStatus with the entered fields", () => {
+    render(<Board projectPrefix="AUTH" projectId="p1" />, { wrapper });
+    fireEvent.click(screen.getByText("+ Add column"));
+    fireEvent.change(screen.getByLabelText("New column name"), { target: { value: "QA" } });
+    fireEvent.change(screen.getByLabelText("New column category"), { target: { value: "completed" } });
+    fireEvent.change(screen.getByLabelText("New column color"), { target: { value: "#112233" } });
+    fireEvent.click(screen.getByText("Add"));
+
+    const call = mutateMock.mock.calls.at(-1);
+    expect(call).toBeTruthy();
+    const op = call?.[0] as { op: string; args: Record<string, unknown> };
+    expect(op.op).toBe("CreateStatus");
+    expect(op.args).toMatchObject({
+      project_id: "p1",
+      name: "QA",
+      category: "completed",
+      color: "#112233",
+      position: 2,
+    });
+    expect(typeof op.args.id).toBe("string");
   });
 });

--- a/ui/tests/components/board/BoardColumn.test.tsx
+++ b/ui/tests/components/board/BoardColumn.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { DndContext } from "@dnd-kit/core";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { IssueDto, StatusDto } from "@/data/bindings";
+
+const mutateMock = vi.hoisted(() => vi.fn());
+vi.mock("@/data/mutations", () => ({
+  useApply: () => ({ mutate: mutateMock, isPending: false }),
+}));
+
+import { BoardColumn } from "@/components/board/BoardColumn";
+
+beforeEach(() => {
+  mutateMock.mockReset();
+});
+
+const status: StatusDto = {
+  id: "s1",
+  project_id: "p1",
+  name: "To Do",
+  category: "unstarted",
+  color: "#94a3b8",
+  position: 0,
+};
+
+const issues: IssueDto[] = [];
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <MemoryRouter>
+      <DndContext>{children}</DndContext>
+    </MemoryRouter>
+  );
+}
+
+function renderColumn(props: Partial<Parameters<typeof BoardColumn>[0]> = {}) {
+  return render(
+    <BoardColumn
+      status={status}
+      issues={issues}
+      projectPrefix="AUTH"
+      onAddIssue={() => {}}
+      index={1}
+      count={3}
+      {...props}
+    />,
+    { wrapper },
+  );
+}
+
+/** Typed access to the most recent `apply.mutate(op, ...)` call. */
+function lastOp(): { op: string; args: Record<string, unknown> } {
+  const call = mutateMock.mock.calls.at(-1);
+  if (!call) throw new Error("mutate was not called");
+  return call[0] as { op: string; args: Record<string, unknown> };
+}
+
+function openMenu() {
+  fireEvent.click(screen.getByLabelText("Column actions for To Do"));
+}
+
+describe("BoardColumn column management", () => {
+  it("rename dispatches UpdateStatus with a name patch on Enter", () => {
+    renderColumn();
+    openMenu();
+    fireEvent.click(screen.getByText("Rename"));
+    const input = screen.getByLabelText("Rename column");
+    fireEvent.change(input, { target: { value: "QA" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(lastOp()).toEqual({ op: "UpdateStatus", args: { id: "s1", patch: { name: "QA" } } });
+  });
+
+  it("rename does not dispatch when unchanged", () => {
+    renderColumn();
+    openMenu();
+    fireEvent.click(screen.getByText("Rename"));
+    const input = screen.getByLabelText("Rename column");
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(mutateMock).not.toHaveBeenCalled();
+  });
+
+  it("recolor dispatches UpdateStatus with a color patch", () => {
+    renderColumn();
+    openMenu();
+    fireEvent.change(screen.getByLabelText("Column color"), { target: { value: "#ff0000" } });
+    expect(lastOp()).toEqual({
+      op: "UpdateStatus",
+      args: { id: "s1", patch: { color: "#ff0000" } },
+    });
+  });
+
+  it("delete dispatches DeleteStatus", () => {
+    renderColumn();
+    openMenu();
+    fireEvent.click(screen.getByText("Delete"));
+    expect(lastOp()).toEqual({ op: "DeleteStatus", args: { id: "s1" } });
+  });
+
+  it("surfaces the core error message when delete is blocked", () => {
+    mutateMock.mockImplementation(
+      (_op: unknown, opts?: { onError?: (e: unknown) => void }) => {
+        opts?.onError?.({ kind: "Conflict", message: "status still has issues" });
+      },
+    );
+    renderColumn();
+    openMenu();
+    fireEvent.click(screen.getByText("Delete"));
+    expect(screen.getByText("status still has issues")).toBeInTheDocument();
+  });
+
+  it("move left dispatches ReorderStatus with index-1", () => {
+    renderColumn({ index: 1, count: 3 });
+    openMenu();
+    fireEvent.click(screen.getByLabelText("Move column left"));
+    expect(lastOp()).toEqual({ op: "ReorderStatus", args: { id: "s1", new_position: 0 } });
+  });
+
+  it("move right dispatches ReorderStatus with index+1", () => {
+    renderColumn({ index: 1, count: 3 });
+    openMenu();
+    fireEvent.click(screen.getByLabelText("Move column right"));
+    expect(lastOp()).toEqual({ op: "ReorderStatus", args: { id: "s1", new_position: 2 } });
+  });
+
+  it("disables move left at index 0", () => {
+    renderColumn({ index: 0, count: 3 });
+    openMenu();
+    expect(screen.getByLabelText("Move column left")).toBeDisabled();
+  });
+
+  it("disables move right at the last index", () => {
+    renderColumn({ index: 2, count: 3 });
+    openMenu();
+    expect(screen.getByLabelText("Move column right")).toBeDisabled();
+  });
+});

--- a/ui/tests/data/mutations.test.tsx
+++ b/ui/tests/data/mutations.test.tsx
@@ -61,6 +61,30 @@ describe("useApply optimistic dispatcher", () => {
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["issues"] });
   });
 
+  it("invalidates statuses + issues on CreateStatus", async () => {
+    applyMock.mockResolvedValueOnce({ status: "ok", data: { op_id: 9 } });
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+
+    const { result } = renderHook(() => useApply("AUTH"), { wrapper: makeWrapper(client) });
+    await act(async () => {
+      result.current.mutate(
+        ops.createStatus({
+          id: "s9",
+          project_id: "p1",
+          name: "QA",
+          category: "started",
+          color: "#94a3b8",
+          position: 3,
+        }),
+      );
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: qk.statuses("AUTH") });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: qk.issues("AUTH") });
+  });
+
   it("optimistically adds a created project to the cache on success", async () => {
     applyMock.mockResolvedValueOnce({ status: "ok", data: { op_id: 7 } });
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/ui/tests/data/ops.test.ts
+++ b/ui/tests/data/ops.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { ops, change, sortKeyBits } from "@/data/ops";
+import { ops, change, sortKeyBits, STATUS_CATEGORIES } from "@/data/ops";
 
 describe("ops builders", () => {
   it("createProject wraps args under {op,args}", () => {
@@ -77,6 +77,71 @@ describe("ops builders", () => {
       op: "UpdateLabel",
       args: { id: "l1", patch: { color: "#0f0" } },
     });
+  });
+
+  it("createStatus wraps args under {op,args}", () => {
+    expect(
+      ops.createStatus({
+        id: "s1",
+        project_id: "p1",
+        name: "QA",
+        category: "started",
+        color: "#94a3b8",
+        position: 2,
+      }),
+    ).toEqual({
+      op: "CreateStatus",
+      args: {
+        id: "s1",
+        project_id: "p1",
+        name: "QA",
+        category: "started",
+        color: "#94a3b8",
+        position: 2,
+      },
+    });
+  });
+
+  it("updateStatus wraps a name patch", () => {
+    expect(ops.updateStatus({ id: "s1", name: "QA" })).toEqual({
+      op: "UpdateStatus",
+      args: { id: "s1", patch: { name: "QA" } },
+    });
+  });
+
+  it("updateStatus wraps a color patch", () => {
+    expect(ops.updateStatus({ id: "s1", color: "#0f0" })).toEqual({
+      op: "UpdateStatus",
+      args: { id: "s1", patch: { color: "#0f0" } },
+    });
+  });
+
+  it("updateStatus omits undefined fields from the patch", () => {
+    expect(ops.updateStatus({ id: "s1", category: "completed" })).toEqual({
+      op: "UpdateStatus",
+      args: { id: "s1", patch: { category: "completed" } },
+    });
+  });
+
+  it("deleteStatus takes just id", () => {
+    expect(ops.deleteStatus({ id: "s1" })).toEqual({ op: "DeleteStatus", args: { id: "s1" } });
+  });
+
+  it("reorderStatus carries id and new_position", () => {
+    expect(ops.reorderStatus({ id: "s1", new_position: 0 })).toEqual({
+      op: "ReorderStatus",
+      args: { id: "s1", new_position: 0 },
+    });
+  });
+
+  it("exposes the five status categories", () => {
+    expect(STATUS_CATEGORIES).toEqual([
+      "unstarted",
+      "started",
+      "blocked",
+      "completed",
+      "discarded",
+    ]);
   });
 
   it("archiveProject / deleteProject / deleteLabel take just id", () => {


### PR DESCRIPTION
## Summary

**Spec #5 — Custom Statuses**: makes the board's columns user-editable. Adds four undoable core operations and exposes them in the GUI and CLI. No migration; no DTO change (the generic `apply` command and the MCP server need no changes for writes).

**Core (`kanban-core`)** — mirrors the existing label ops:
- `CreateStatus` (validates name + hex color; rejects duplicate `(project_id, name)`), `UpdateStatus` (via `StatusPatch{name?,category?,color?}`), `DeleteStatus`, `ReorderStatus`.
- **`DeleteStatus` is guarded (block-until-empty):** refuses with `Error::Conflict` if the status still has issues, or if it's the project's **last** column.
- **`ReorderStatus`** re-packs the project's columns to dense `0..n` positions. Undo inverses: Create→Delete, Update→Update(prior), Delete→`ImportSnapshot`(row), Reorder→`ImportSnapshot`(project ordering). All covered by the apply→assert→undo→assert-restored test cycle.

**GUI** — board column management: a per-column menu (rename inline, recolor, move left/right, delete) and an "+ Add column" form (name + category + color); delete-block messages surface inline. `mutations.ts` now invalidates `qk.statuses`/`qk.issues` on status ops.

**CLI** — `kanban status create | update | delete | reorder` (delete requires `--yes`; the core block-guards surface as a non-zero exit).

**Deferred:** members/assignees → **Spec #6** (needs a migration). MCP status-management tools and drag-to-reorder columns — later.

## Test plan
- [x] Rust: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` — all green (8 new `apply_statuses` core tests + 8 CLI `status_cmds` tests).
- [x] UI: `pnpm typecheck`, `pnpm lint` (no `any`), `pnpm test:unit` (93 tests), `pnpm build` — all green.
- [x] No migration, no bindings drift (StatusDto already existed); every write through `Workspace::apply`.
- [ ] Manual smoke: add a column, rename/recolor/reorder it, delete an empty column, attempt to delete a non-empty one (blocked), ⌘Z to undo — in the running app and via `kanban status`.