### PR TITLE
v2: Spec #6 — Members & Assignees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,8 @@ The GUI is `crates/kanban-tauri` (Rust shell) + `ui/` (Vite + React 19 + Tailwin
 
 - **Custom statuses (Spec #5).** Four undoable core ops — `CreateStatus`, `UpdateStatus` (via `StatusPatch`), `DeleteStatus`, `ReorderStatus` — mirroring the label ops (`apply/statuses.rs` + `store/{write,read}/statuses.rs` + `apply/mod.rs` arms; no migration, no DTO change). **`DeleteStatus` is guarded:** it refuses (`Error::Conflict`) if the status still has issues or is the project's last column (block-until-empty). `ReorderStatus` re-packs the project's columns to dense `0..n` positions; its undo inverse is an `ImportSnapshot` of the project's prior status ordering (delete's inverse snapshots the single row). Exposed in the GUI (board column add/rename/recolor/reorder/delete) and the CLI (`kanban status create/update/delete/reorder`); the generic Tauri `apply` and the MCP server need no changes.
 
+- **Members & assignees (Spec #6).** Migration `0003_members.sql` adds a per-project `members` table + a nullable `issues.assignee_id` (`REFERENCES members(id) ON DELETE SET NULL`). Ops `CreateMember`/`UpdateMember`/`DeleteMember` mirror the label ops; **assignment reuses `UpdateIssueField` via `IssueFieldChange::Assignee(Option<Uuid>)`** (validated: the member must be in the issue's project). `WorkspaceSnapshot` gained `members` and bumped to **schema v2**; `DeleteMember`'s undo inverse is an `ImportSnapshot` capturing the member + its assigned issues **and their `issue_labels`** (the Overwrite re-import tears down + restores those rows). `Issue` gained `assignee_id` — it threads through `row_to_issue`, every snapshot issue read/write, and `IssueDto`. Exposed in the GUI (assignee picker + member roster in the detail panel) and the CLI (`kanban member …`, `kanban issue assign`). MCP member tools are deferred to Spec #7.
+
 ## MCP layer (Spec #3)
 
 The MCP server is `crates/kanban-mcp` — a stdio server (on `rmcp`) exposing `kanban-core` to AI assistants (Claude Desktop/Code). Design: `docs/superpowers/specs/2026-06-05-kanban-v2-spec-3-mcp-server-design.md`.
@@ -97,5 +99,6 @@ These don't block v1 but should be addressed before broader release:
 - `docs/superpowers/specs/2026-06-05-kanban-v2-spec-3-mcp-server-design.md` — Spec #3 (MCP server).
 - `docs/superpowers/specs/2026-06-06-kanban-v2-spec-4-gui-product-completeness-design.md` — Spec #4 (GUI product completeness).
 - `docs/superpowers/specs/2026-06-06-kanban-v2-spec-5-custom-statuses-design.md` — Spec #5 (custom statuses).
+- `docs/superpowers/specs/2026-06-06-kanban-v2-spec-6-members-assignees-design.md` — Spec #6 (members & assignees).
 
-Each spec has a matching plan in `docs/superpowers/plans/`. Members/assignee (Spec #6) and AI-agent orchestration will live alongside.
+Each spec has a matching plan in `docs/superpowers/plans/`. AI-agent orchestration, MCP member tools, and other follow-ups (Spec #7+) will live alongside.

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ By default the workspace lives at `~/.kanban/data.db`. Override with `KANBAN_DB=
 A macOS desktop GUI (Tauri + React) ships alongside the CLI, built on the same
 `kanban-core` library: a drag-and-drop kanban board with editable columns
 (add / rename / recolor / reorder / delete), a markdown issue detail panel
-with priority / due-date / label editing and delete, a project sidebar with
-rename / archive / delete, ⌘Z / ⌘⇧Z undo-redo, and light/dark/system
-theming.
+with priority / due-date / label / assignee editing and delete, a per-project
+member roster, a project sidebar with rename / archive / delete, ⌘Z / ⌘⇧Z
+undo-redo, and light/dark/system theming.
 
 Download the latest macOS DMG from
 [GitHub Releases](https://github.com/akassharjun/kanban/releases). The first

--- a/crates/kanban-cli/src/cli.rs
+++ b/crates/kanban-cli/src/cli.rs
@@ -43,6 +43,8 @@ pub enum Cmd {
     Label(crate::cmd::label::LabelCmd),
     /// Manage statuses.
     Status(crate::cmd::status::StatusCmd),
+    /// Manage project members.
+    Member(crate::cmd::member::MemberCmd),
     /// Full-text search across issues.
     Search(crate::cmd::search::SearchArgs),
     /// Export the workspace as a JSON snapshot.

--- a/crates/kanban-cli/src/cmd/issue.rs
+++ b/crates/kanban-cli/src/cmd/issue.rs
@@ -98,6 +98,15 @@ pub enum IssueSub {
         #[arg(long, conflicts_with = "before")]
         after: Option<String>,
     },
+    /// Assign (or unassign) an issue to a project member by name.
+    Assign {
+        identifier: String,
+        /// Member name within the issue's project. Omit with `--unassign`.
+        member: Option<String>,
+        /// Clear the assignee instead of setting one.
+        #[arg(long)]
+        unassign: bool,
+    },
     /// Delete an issue (requires `--yes`).
     Delete {
         identifier: String,
@@ -182,6 +191,11 @@ pub fn run(cmd: IssueCmd, ws: &mut Workspace, out: &Out) -> Result<()> {
             before,
             after,
         } => reorder(ws, out, &identifier, before.as_deref(), after.as_deref()),
+        IssueSub::Assign {
+            identifier,
+            member,
+            unassign,
+        } => assign(ws, out, &identifier, member.as_deref(), unassign),
         IssueSub::Delete { identifier, yes } => delete(ws, out, &identifier, yes),
         IssueSub::History { identifier } => history(ws, out, &identifier),
     }
@@ -487,6 +501,55 @@ fn move_status(ws: &mut Workspace, out: &Out, identifier: &str, status: &str) ->
         println!("moved {} to {}", after.identifier, status);
     }
     Ok(())
+}
+
+fn assign(
+    ws: &mut Workspace,
+    out: &Out,
+    identifier: &str,
+    member: Option<&str>,
+    unassign: bool,
+) -> Result<()> {
+    let issue = resolve_issue(ws, identifier)?;
+    let change = if unassign {
+        IssueFieldChange::Assignee(None)
+    } else {
+        let name = member.ok_or_else(|| {
+            kanban_core::Error::Validation(kanban_core::ValidationError {
+                field: "member".into(),
+                reason: "supply a member name or pass --unassign".into(),
+            })
+        })?;
+        let m = resolve_member(ws, issue.project_id, name)?;
+        IssueFieldChange::Assignee(Some(m.id))
+    };
+    ws.apply(Operation::UpdateIssueField(UpdateIssueField {
+        id: issue.id,
+        change,
+    }))?;
+    let after = ws.query_issue_by_id(issue.id)?;
+    if out.json {
+        out.print_json(&after)?;
+    } else if unassign {
+        println!("unassigned {}", after.identifier);
+    } else {
+        println!(
+            "assigned {} to {}",
+            after.identifier,
+            member.unwrap_or_default()
+        );
+    }
+    Ok(())
+}
+
+fn resolve_member(ws: &Workspace, project_id: Uuid, name: &str) -> Result<kanban_core::Member> {
+    ws.query_members_for_project(project_id)?
+        .into_iter()
+        .find(|m| m.name == name)
+        .ok_or(kanban_core::Error::NotFound {
+            kind: kanban_core::EntityKind::Member,
+            id: name.to_string(),
+        })
 }
 
 fn reorder(

--- a/crates/kanban-cli/src/cmd/member.rs
+++ b/crates/kanban-cli/src/cmd/member.rs
@@ -1,0 +1,182 @@
+//! `kanban member` subcommands.
+//!
+//! Members are scoped to a project and addressed by name within that project.
+//! Besides the read-only `list`, this module provides `create`, `update`, and
+//! `delete` write subcommands mirroring `kanban label`.
+
+use crate::output::Out;
+use clap::{Args, Subcommand};
+use kanban_core::operation::{CreateMember, DeleteMember, MemberPatch, Operation, UpdateMember};
+use kanban_core::{Member, Project, Result, Workspace, new_id};
+use uuid::Uuid;
+
+#[derive(Debug, Args)]
+pub struct MemberCmd {
+    #[command(subcommand)]
+    pub sub: MemberSub,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum MemberSub {
+    /// List members for a project.
+    List {
+        #[arg(long)]
+        project: String,
+    },
+    /// Create a member.
+    Create {
+        #[arg(long)]
+        project: String,
+        #[arg(long)]
+        name: String,
+    },
+    /// Update an existing member by current name.
+    Update {
+        #[arg(long)]
+        project: String,
+        #[arg(long)]
+        name: String,
+        #[arg(long)]
+        rename: Option<String>,
+    },
+    /// Delete a member (requires `--yes`).
+    Delete {
+        #[arg(long)]
+        project: String,
+        #[arg(long)]
+        name: String,
+        #[arg(long)]
+        yes: bool,
+    },
+}
+
+/// Dispatch a `kanban member` invocation.
+///
+/// # Errors
+///
+/// Propagates errors from the underlying [`Workspace`] operations and from
+/// validation in the dispatched subcommand handlers.
+#[allow(clippy::needless_pass_by_value)]
+pub fn run(cmd: MemberCmd, ws: &mut Workspace, out: &Out) -> Result<()> {
+    match cmd.sub {
+        MemberSub::List { project } => list(ws, out, &project),
+        MemberSub::Create { project, name } => create(ws, out, &project, name),
+        MemberSub::Update {
+            project,
+            name,
+            rename,
+        } => update(ws, out, &project, &name, rename),
+        MemberSub::Delete { project, name, yes } => delete(ws, out, &project, &name, yes),
+    }
+}
+
+fn resolve_project(ws: &Workspace, id_or_prefix: &str) -> Result<Project> {
+    if let Ok(uuid) = Uuid::parse_str(id_or_prefix) {
+        return ws.query_project_by_id(uuid);
+    }
+    ws.query_projects()?
+        .into_iter()
+        .find(|p| p.prefix == id_or_prefix)
+        .ok_or(kanban_core::Error::NotFound {
+            kind: kanban_core::EntityKind::Project,
+            id: id_or_prefix.to_string(),
+        })
+}
+
+fn resolve_member_by_name(ws: &Workspace, project_id: Uuid, name: &str) -> Result<Member> {
+    ws.query_members_for_project(project_id)?
+        .into_iter()
+        .find(|m| m.name == name)
+        .ok_or(kanban_core::Error::NotFound {
+            kind: kanban_core::EntityKind::Member,
+            id: name.to_string(),
+        })
+}
+
+fn list(ws: &Workspace, out: &Out, project: &str) -> Result<()> {
+    let p = resolve_project(ws, project)?;
+    let members = ws.query_members_for_project(p.id)?;
+    if out.json {
+        out.print_json(&members)?;
+    } else {
+        for m in &members {
+            println!("{}", m.name);
+        }
+    }
+    Ok(())
+}
+
+fn create(ws: &mut Workspace, out: &Out, project: &str, name: String) -> Result<()> {
+    let p = resolve_project(ws, project)?;
+    let id = new_id();
+    ws.apply(Operation::CreateMember(CreateMember {
+        id,
+        project_id: p.id,
+        name,
+    }))?;
+    let created = resolve_member_by_id(ws, p.id, id)?;
+    if out.json {
+        out.print_json(&created)?;
+    } else {
+        println!("created {}", created.name);
+    }
+    Ok(())
+}
+
+fn update(
+    ws: &mut Workspace,
+    out: &Out,
+    project: &str,
+    name: &str,
+    rename: Option<String>,
+) -> Result<()> {
+    let p = resolve_project(ws, project)?;
+    let member = resolve_member_by_name(ws, p.id, name)?;
+    if rename.is_none() {
+        return Err(kanban_core::Error::Validation(
+            kanban_core::ValidationError {
+                field: "fields".into(),
+                reason: "supply --rename".into(),
+            },
+        ));
+    }
+    ws.apply(Operation::UpdateMember(UpdateMember {
+        id: member.id,
+        patch: MemberPatch { name: rename },
+    }))?;
+    let updated = resolve_member_by_id(ws, p.id, member.id)?;
+    if out.json {
+        out.print_json(&updated)?;
+    } else {
+        println!("updated {}", updated.name);
+    }
+    Ok(())
+}
+
+fn delete(ws: &mut Workspace, out: &Out, project: &str, name: &str, yes: bool) -> Result<()> {
+    if !yes {
+        return Err(kanban_core::Error::Validation(
+            kanban_core::ValidationError {
+                field: "confirm".into(),
+                reason: "pass --yes to confirm deletion".into(),
+            },
+        ));
+    }
+    let p = resolve_project(ws, project)?;
+    let member = resolve_member_by_name(ws, p.id, name)?;
+    ws.apply(Operation::DeleteMember(DeleteMember { id: member.id }))?;
+    if !out.json {
+        println!("deleted {}", member.name);
+    }
+    Ok(())
+}
+
+fn resolve_member_by_id(ws: &Workspace, project_id: Uuid, id: Uuid) -> Result<Member> {
+    ws.query_members_for_project(project_id)?
+        .into_iter()
+        .find(|m| m.id == id)
+        .ok_or(kanban_core::Error::NotFound {
+            kind: kanban_core::EntityKind::Member,
+            id: id.to_string(),
+        })
+}

--- a/crates/kanban-cli/src/cmd/mod.rs
+++ b/crates/kanban-cli/src/cmd/mod.rs
@@ -6,6 +6,7 @@ pub mod export;
 pub mod import;
 pub mod issue;
 pub mod label;
+pub mod member;
 pub mod project;
 pub mod search;
 pub mod status;

--- a/crates/kanban-cli/src/main.rs
+++ b/crates/kanban-cli/src/main.rs
@@ -43,6 +43,7 @@ fn run(args: Cli) -> kanban_core::Result<()> {
         Cmd::Issue(c) => cmd::issue::run(c, &mut ws, &out),
         Cmd::Label(c) => cmd::label::run(c, &mut ws, &out),
         Cmd::Status(c) => cmd::status::run(c, &mut ws, &out),
+        Cmd::Member(c) => cmd::member::run(c, &mut ws, &out),
         Cmd::Search(c) => cmd::search::run(c, &ws, &out),
         Cmd::Export(c) => cmd::export::run(c, &ws, &out),
         Cmd::Import(c) => cmd::import::run(c, &mut ws, &out),

--- a/crates/kanban-cli/tests/issue_assign.rs
+++ b/crates/kanban-cli/tests/issue_assign.rs
@@ -1,0 +1,104 @@
+//! Integration tests for `kanban issue assign` / `--unassign`.
+
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::panic)]
+
+use assert_cmd::Command;
+use std::path::PathBuf;
+
+fn isolated_db() -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("data.db");
+    (dir, path)
+}
+
+fn cli(db: &PathBuf) -> Command {
+    let mut c = Command::cargo_bin("kanban").unwrap();
+    c.env("KANBAN_DB", db);
+    c
+}
+
+fn setup(db: &PathBuf) {
+    cli(db)
+        .args(["project", "create", "Auth", "--prefix", "AUTH"])
+        .assert()
+        .success();
+    cli(db)
+        .args(["member", "create", "--project", "AUTH", "--name", "Alice"])
+        .assert()
+        .success();
+    cli(db)
+        .args(["issue", "create", "--project", "AUTH", "--title", "login"])
+        .assert()
+        .success();
+}
+
+fn assignee(db: &PathBuf) -> Option<String> {
+    let out = cli(db)
+        .args(["--json", "issue", "show", "AUTH-1"])
+        .output()
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    v["assignee_id"].as_str().map(ToString::to_string)
+}
+
+#[test]
+fn issue_assign_sets_assignee() {
+    let (_d, db) = isolated_db();
+    setup(&db);
+    assert!(assignee(&db).is_none());
+    cli(&db)
+        .args(["issue", "assign", "AUTH-1", "Alice"])
+        .assert()
+        .success();
+    assert!(assignee(&db).is_some());
+}
+
+#[test]
+fn issue_unassign_clears_assignee() {
+    let (_d, db) = isolated_db();
+    setup(&db);
+    cli(&db)
+        .args(["issue", "assign", "AUTH-1", "Alice"])
+        .assert()
+        .success();
+    assert!(assignee(&db).is_some());
+    cli(&db)
+        .args(["issue", "assign", "AUTH-1", "--unassign"])
+        .assert()
+        .success();
+    assert!(assignee(&db).is_none());
+}
+
+#[test]
+fn issue_assign_unknown_member_exits_not_found() {
+    let (_d, db) = isolated_db();
+    setup(&db);
+    let assert = cli(&db)
+        .args(["issue", "assign", "AUTH-1", "Ghost"])
+        .assert()
+        .failure();
+    // NotFound maps to EXIT_NOT_FOUND (2).
+    assert.code(2);
+}
+
+#[test]
+fn issue_assign_foreign_member_exits_validation() {
+    let (_d, db) = isolated_db();
+    setup(&db);
+    // A member in a different project must not be assignable to AUTH-1.
+    cli(&db)
+        .args(["project", "create", "Other", "--prefix", "OTH"])
+        .assert()
+        .success();
+    cli(&db)
+        .args(["member", "create", "--project", "OTH", "--name", "Bob"])
+        .assert()
+        .success();
+    // Resolving by name within AUTH's project won't find Bob -> NotFound (2).
+    let assert = cli(&db)
+        .args(["issue", "assign", "AUTH-1", "Bob"])
+        .assert()
+        .failure();
+    assert.code(2);
+}

--- a/crates/kanban-cli/tests/member_cmds.rs
+++ b/crates/kanban-cli/tests/member_cmds.rs
@@ -1,0 +1,164 @@
+//! Integration tests for `kanban member` write subcommands.
+
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::panic)]
+
+use assert_cmd::Command;
+use std::path::PathBuf;
+
+fn isolated_db() -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("data.db");
+    (dir, path)
+}
+
+fn cli(db: &PathBuf) -> Command {
+    let mut c = Command::cargo_bin("kanban").unwrap();
+    c.env("KANBAN_DB", db);
+    c
+}
+
+fn make_project(db: &PathBuf) {
+    cli(db)
+        .args(["project", "create", "P", "--prefix", "PRJ"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn member_create_then_list() {
+    let (_d, db) = isolated_db();
+    make_project(&db);
+    cli(&db)
+        .args(["member", "create", "--project", "PRJ", "--name", "Alice"])
+        .assert()
+        .success();
+    let out = cli(&db)
+        .args(["member", "list", "--project", "PRJ"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    insta::assert_snapshot!("member_list_with_alice", stdout);
+}
+
+#[test]
+fn member_create_duplicate_name_exits_nonzero() {
+    let (_d, db) = isolated_db();
+    make_project(&db);
+    cli(&db)
+        .args(["member", "create", "--project", "PRJ", "--name", "Alice"])
+        .assert()
+        .success();
+    let assert = cli(&db)
+        .args(["member", "create", "--project", "PRJ", "--name", "Alice"])
+        .assert()
+        .failure();
+    // Conflict/validation maps to EXIT_VALIDATION (3).
+    assert.code(3);
+}
+
+#[test]
+fn member_update_rename() {
+    let (_d, db) = isolated_db();
+    make_project(&db);
+    cli(&db)
+        .args(["member", "create", "--project", "PRJ", "--name", "Alice"])
+        .assert()
+        .success();
+    cli(&db)
+        .args([
+            "member",
+            "update",
+            "--project",
+            "PRJ",
+            "--name",
+            "Alice",
+            "--rename",
+            "Alicia",
+        ])
+        .assert()
+        .success();
+    let out = cli(&db)
+        .args(["--json", "member", "list", "--project", "PRJ"])
+        .output()
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let names: Vec<&str> = v
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|m| m["name"].as_str().unwrap())
+        .collect();
+    assert!(names.contains(&"Alicia"));
+    assert!(!names.contains(&"Alice"));
+}
+
+#[test]
+fn member_delete_with_yes_succeeds() {
+    let (_d, db) = isolated_db();
+    make_project(&db);
+    cli(&db)
+        .args(["member", "create", "--project", "PRJ", "--name", "Alice"])
+        .assert()
+        .success();
+    cli(&db)
+        .args([
+            "member",
+            "delete",
+            "--project",
+            "PRJ",
+            "--name",
+            "Alice",
+            "--yes",
+        ])
+        .assert()
+        .success();
+    let out = cli(&db)
+        .args(["--json", "member", "list", "--project", "PRJ"])
+        .output()
+        .unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let names: Vec<&str> = v
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|m| m["name"].as_str().unwrap())
+        .collect();
+    assert!(!names.contains(&"Alice"));
+}
+
+#[test]
+fn member_delete_without_yes_exits_validation() {
+    let (_d, db) = isolated_db();
+    make_project(&db);
+    cli(&db)
+        .args(["member", "create", "--project", "PRJ", "--name", "Alice"])
+        .assert()
+        .success();
+    let assert = cli(&db)
+        .args(["member", "delete", "--project", "PRJ", "--name", "Alice"])
+        .assert()
+        .failure();
+    assert.code(3);
+}
+
+#[test]
+fn member_update_unknown_name_exits_nonzero() {
+    let (_d, db) = isolated_db();
+    make_project(&db);
+    let assert = cli(&db)
+        .args([
+            "member",
+            "update",
+            "--project",
+            "PRJ",
+            "--name",
+            "Ghost",
+            "--rename",
+            "Boo",
+        ])
+        .assert()
+        .failure();
+    // NotFound maps to EXIT_NOT_FOUND (2).
+    assert.code(2);
+}

--- a/crates/kanban-cli/tests/snapshots/member_cmds__member_list_with_alice.snap
+++ b/crates/kanban-cli/tests/snapshots/member_cmds__member_list_with_alice.snap
@@ -1,0 +1,5 @@
+---
+source: crates/kanban-cli/tests/member_cmds.rs
+expression: stdout
+---
+Alice

--- a/crates/kanban-core/migrations/0003_members.sql
+++ b/crates/kanban-core/migrations/0003_members.sql
@@ -1,0 +1,10 @@
+CREATE TABLE members (
+  id         TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  name       TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  UNIQUE (project_id, name)
+) STRICT;
+CREATE INDEX idx_members_project ON members(project_id);
+
+ALTER TABLE issues ADD COLUMN assignee_id TEXT REFERENCES members(id) ON DELETE SET NULL;

--- a/crates/kanban-core/src/apply/issues.rs
+++ b/crates/kanban-core/src/apply/issues.rs
@@ -163,6 +163,27 @@ pub(crate) fn update_field(
             };
             crate::store::write::issues::update_field(tx, args.id, "due_date", v, now)?;
         }
+        IssueFieldChange::Assignee(new) => {
+            let v = match new {
+                Some(member_id) => {
+                    // The member must belong to the same project as the issue.
+                    let same_project: bool = tx.query_row(
+                        "SELECT COUNT(*) FROM members WHERE id = ?1 AND project_id = ?2",
+                        params![member_id.to_string(), issue.project_id.to_string()],
+                        |r| r.get::<_, i64>(0).map(|n| n > 0),
+                    )?;
+                    if !same_project {
+                        return Err(Error::Validation(crate::error::ValidationError {
+                            field: "assignee".into(),
+                            reason: "must be a member of the same project".into(),
+                        }));
+                    }
+                    Value::Text(member_id.to_string())
+                }
+                None => Value::Null,
+            };
+            crate::store::write::issues::update_field(tx, args.id, "assignee_id", v, now)?;
+        }
     }
     Ok(())
 }
@@ -178,6 +199,7 @@ pub(crate) fn inverse_of_update_field(
         IssueFieldChange::Status(_) => IssueFieldChange::Status(issue.status_id),
         IssueFieldChange::Priority(_) => IssueFieldChange::Priority(issue.priority),
         IssueFieldChange::DueDate(_) => IssueFieldChange::DueDate(issue.due_date),
+        IssueFieldChange::Assignee(_) => IssueFieldChange::Assignee(issue.assignee_id),
     };
     Ok(Operation::UpdateIssueField(UpdateIssueField {
         id: args.id,

--- a/crates/kanban-core/src/apply/members.rs
+++ b/crates/kanban-core/src/apply/members.rs
@@ -1,0 +1,67 @@
+use crate::error::{Error, Result};
+use crate::operation::{
+    ConflictPolicy, CreateMember, DeleteMember, ImportSnapshot, MemberPatch, Operation,
+    UpdateMember,
+};
+use crate::store::write::members as wm;
+use crate::validate;
+use chrono::{DateTime, Utc};
+use rusqlite::{Transaction, params};
+
+pub(crate) fn create(tx: &Transaction<'_>, args: &CreateMember, now: DateTime<Utc>) -> Result<()> {
+    validate::nonempty_field("name", &args.name)?;
+    let exists: bool = tx.query_row(
+        "SELECT COUNT(*) FROM members WHERE project_id = ?1 AND name = ?2",
+        params![args.project_id.to_string(), &args.name],
+        |r| r.get::<_, i64>(0).map(|n| n > 0),
+    )?;
+    if exists {
+        return Err(Error::Conflict(format!(
+            "member '{}' already exists in project",
+            args.name
+        )));
+    }
+    wm::insert(tx, args.id, args.project_id, &args.name, now)?;
+    Ok(())
+}
+
+pub(crate) fn update(tx: &Transaction<'_>, args: &UpdateMember) -> Result<()> {
+    if let Some(n) = &args.patch.name {
+        validate::nonempty_field("name", n)?;
+    }
+    wm::update_fields(tx, args.id, args.patch.name.as_deref())?;
+    Ok(())
+}
+
+pub(crate) fn delete(tx: &Transaction<'_>, args: &DeleteMember) -> Result<()> {
+    // member must exist — by_id_via_tx errors NotFound if absent.
+    crate::store::read::members::by_id_via_tx(tx, args.id)?;
+    // The DB nulls any dependent issues.assignee_id via ON DELETE SET NULL.
+    wm::delete(tx, args.id)?;
+    Ok(())
+}
+
+pub(crate) fn inverse_of_create(args: &CreateMember) -> Operation {
+    Operation::DeleteMember(DeleteMember { id: args.id })
+}
+
+pub(crate) fn inverse_of_update(tx: &Transaction<'_>, args: &UpdateMember) -> Result<Operation> {
+    let m = crate::store::read::members::by_id_via_tx(tx, args.id)?;
+    Ok(Operation::UpdateMember(UpdateMember {
+        id: m.id,
+        patch: MemberPatch {
+            name: args.patch.name.as_ref().map(|_| m.name),
+        },
+    }))
+}
+
+/// Capture the inverse of `DeleteMember` as an `ImportSnapshot` carrying the
+/// member row + every issue whose `assignee_id` referenced it, so undo restores
+/// the member AND re-applies the assignments that `ON DELETE SET NULL` cleared.
+pub(crate) fn inverse_of_delete(tx: &Transaction<'_>, args: &DeleteMember) -> Result<Operation> {
+    let snapshot = crate::apply::snapshot::export_member_subtree(tx, args.id)?;
+    Ok(Operation::ImportSnapshot(ImportSnapshot {
+        snapshot,
+        policy: ConflictPolicy::Overwrite,
+    }))
+}

--- a/crates/kanban-core/src/apply/mod.rs
+++ b/crates/kanban-core/src/apply/mod.rs
@@ -5,6 +5,7 @@ use crate::workspace::Workspace;
 
 pub(crate) mod issues;
 pub(crate) mod labels;
+pub(crate) mod members;
 pub(crate) mod projects;
 pub(crate) mod snapshot;
 pub(crate) mod statuses;
@@ -86,6 +87,9 @@ pub(crate) fn dispatch(
         Operation::UpdateStatus(args) => statuses::update(tx, args)?,
         Operation::DeleteStatus(args) => statuses::delete(tx, args)?,
         Operation::ReorderStatus(args) => statuses::reorder(tx, args)?,
+        Operation::CreateMember(args) => members::create(tx, args, now)?,
+        Operation::UpdateMember(args) => members::update(tx, args)?,
+        Operation::DeleteMember(args) => members::delete(tx, args)?,
         Operation::ImportSnapshot(args) => snapshot::import(tx, args)?,
     }
     Ok(())
@@ -110,6 +114,9 @@ fn op_type_name(op: &Operation) -> &'static str {
         Operation::UpdateStatus(_) => "UpdateStatus",
         Operation::DeleteStatus(_) => "DeleteStatus",
         Operation::ReorderStatus(_) => "ReorderStatus",
+        Operation::CreateMember(_) => "CreateMember",
+        Operation::UpdateMember(_) => "UpdateMember",
+        Operation::DeleteMember(_) => "DeleteMember",
         Operation::ImportSnapshot(_) => "ImportSnapshot",
     }
 }
@@ -135,6 +142,9 @@ fn capture_inverse(tx: &rusqlite::Transaction<'_>, op: &Operation) -> Result<Ope
         Operation::UpdateStatus(args) => statuses::inverse_of_update(tx, args),
         Operation::DeleteStatus(args) => statuses::inverse_of_delete(tx, args),
         Operation::ReorderStatus(args) => statuses::inverse_of_reorder(tx, args),
+        Operation::CreateMember(args) => Ok(members::inverse_of_create(args)),
+        Operation::UpdateMember(args) => members::inverse_of_update(tx, args),
+        Operation::DeleteMember(args) => members::inverse_of_delete(tx, args),
         Operation::ImportSnapshot(args) => snapshot::inverse_of_import(tx, args),
     }
 }
@@ -228,9 +238,11 @@ fn export_snapshot_via_tx(
         out
     };
 
+    let mut members = Vec::new();
     let mut statuses = Vec::new();
     let mut labels = Vec::new();
     for p in &projects {
+        members.extend(crate::store::read::members::for_project_via_tx(tx, p.id)?);
         statuses.extend(crate::store::read::statuses::for_project_via_tx(tx, p.id)?);
         labels.extend(crate::store::read::labels::for_project_via_tx(tx, p.id)?);
     }
@@ -269,6 +281,7 @@ fn export_snapshot_via_tx(
         schema_version: SNAPSHOT_SCHEMA_VERSION,
         exported_at: chrono::Utc::now(),
         projects,
+        members,
         statuses,
         issues,
         labels,

--- a/crates/kanban-core/src/apply/mod.rs
+++ b/crates/kanban-core/src/apply/mod.rs
@@ -201,6 +201,11 @@ fn emit_activity(
                 pre_issue.due_date.map(|d| d.to_string()),
                 v.map(|d| d.to_string()),
             ),
+            crate::operation::IssueFieldChange::Assignee(v) => (
+                "assignee",
+                pre_issue.assignee_id.map(|a| a.to_string()),
+                v.map(|a| a.to_string()),
+            ),
         };
         let issue_id_s = args.id.to_string();
         crate::store::write::operation_log::insert_activity(

--- a/crates/kanban-core/src/apply/snapshot.rs
+++ b/crates/kanban-core/src/apply/snapshot.rs
@@ -469,7 +469,7 @@ pub(crate) fn export_member_subtree(
     tx: &Transaction<'_>,
     member_id: uuid::Uuid,
 ) -> Result<crate::snapshot::WorkspaceSnapshot> {
-    use crate::snapshot::{SNAPSHOT_SCHEMA_VERSION, WorkspaceSnapshot};
+    use crate::snapshot::{IssueLabelLink, SNAPSHOT_SCHEMA_VERSION, WorkspaceSnapshot};
 
     let member = crate::store::read::members::by_id_via_tx(tx, member_id)?;
 
@@ -489,6 +489,26 @@ pub(crate) fn export_member_subtree(
         }
     }
 
+    // Capture the assigned issues' label attachments too: undoing the delete
+    // re-imports those issues under Overwrite, which deletes+reinserts each issue
+    // row and cascades away its `issue_labels` — so they must be restored here.
+    let mut issue_labels = Vec::new();
+    {
+        let mut stmt = tx.prepare("SELECT label_id FROM issue_labels WHERE issue_id = ?1")?;
+        for issue in &issues {
+            let rows = stmt.query_map(params![issue.id.to_string()], |r| r.get::<_, String>(0))?;
+            for r in rows {
+                let label_id = uuid::Uuid::parse_str(&r?).map_err(|e| {
+                    Error::InvalidSnapshot(format!("issue_labels.label_id is not a uuid: {e}"))
+                })?;
+                issue_labels.push(IssueLabelLink {
+                    issue_id: issue.id,
+                    label_id,
+                });
+            }
+        }
+    }
+
     Ok(WorkspaceSnapshot {
         schema_version: SNAPSHOT_SCHEMA_VERSION,
         exported_at: chrono::Utc::now(),
@@ -497,6 +517,6 @@ pub(crate) fn export_member_subtree(
         statuses: Vec::new(),
         labels: Vec::new(),
         issues,
-        issue_labels: Vec::new(),
+        issue_labels,
     })
 }

--- a/crates/kanban-core/src/apply/snapshot.rs
+++ b/crates/kanban-core/src/apply/snapshot.rs
@@ -14,6 +14,10 @@ pub(crate) fn import(tx: &Transaction<'_>, args: &ImportSnapshot) -> Result<()> 
     for p in &args.snapshot.projects {
         upsert_project(tx, p, args.policy)?;
     }
+    // Members must exist before issues that reference them via assignee_id.
+    for m in &args.snapshot.members {
+        upsert_member(tx, m, args.policy)?;
+    }
     for s in &args.snapshot.statuses {
         upsert_status(tx, s, args.policy)?;
     }
@@ -160,6 +164,42 @@ fn upsert_label(
     Ok(())
 }
 
+fn upsert_member(
+    tx: &Transaction<'_>,
+    m: &crate::types::Member,
+    policy: ConflictPolicy,
+) -> Result<()> {
+    let id = m.id.to_string();
+    let pid = m.project_id.to_string();
+    // A member row collides on either its primary key OR the (project_id, name)
+    // unique constraint. Both have to be considered before the policy gate.
+    let id_clash = exists(tx, "members", &id)?;
+    let name_clash: i64 = tx.query_row(
+        "SELECT COUNT(*) FROM members WHERE project_id = ?1 AND name = ?2",
+        params![pid, m.name],
+        |r| r.get(0),
+    )?;
+    if id_clash || name_clash > 0 {
+        if handle_conflict(policy, crate::EntityKind::Member, &id)? {
+            return Ok(());
+        }
+        if id_clash {
+            tx.execute("DELETE FROM members WHERE id = ?1", params![id])?;
+        }
+        if name_clash > 0 {
+            tx.execute(
+                "DELETE FROM members WHERE project_id = ?1 AND name = ?2",
+                params![pid, m.name],
+            )?;
+        }
+    }
+    tx.execute(
+        "INSERT INTO members(id,project_id,name,created_at) VALUES (?1,?2,?3,?4)",
+        params![id, pid, m.name, m.created_at.to_rfc3339()],
+    )?;
+    Ok(())
+}
+
 fn upsert_issue(
     tx: &Transaction<'_>,
     i: &crate::types::Issue,
@@ -174,8 +214,8 @@ fn upsert_issue(
     }
     tx.execute(
         "INSERT INTO issues(id,project_id,seq,identifier,title,description,status_id,priority,
-                            due_date,sort_key,created_at,updated_at)
-         VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12)",
+                            due_date,sort_key,created_at,updated_at,assignee_id)
+         VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13)",
         params![
             id,
             i.project_id.to_string(),
@@ -189,6 +229,7 @@ fn upsert_issue(
             i.sort_key,
             i.created_at.to_rfc3339(),
             i.updated_at.to_rfc3339(),
+            i.assignee_id.map(|a| a.to_string()),
         ],
     )?;
     Ok(())
@@ -228,6 +269,7 @@ pub(crate) fn export_project_subtree_via_tx(
     use crate::snapshot::{IssueLabelLink, SNAPSHOT_SCHEMA_VERSION, WorkspaceSnapshot};
 
     let project = crate::store::read::projects::by_id_via_tx(tx, project_id)?;
+    let members = crate::store::read::members::for_project_via_tx(tx, project_id)?;
     let statuses = crate::store::read::statuses::for_project_via_tx(tx, project_id)?;
     let labels = crate::store::read::labels::for_project_via_tx(tx, project_id)?;
 
@@ -235,7 +277,7 @@ pub(crate) fn export_project_subtree_via_tx(
     {
         let mut stmt = tx.prepare(
             "SELECT id,project_id,seq,identifier,title,description,status_id,priority,
-                    due_date,sort_key,created_at,updated_at
+                    due_date,sort_key,created_at,updated_at,assignee_id
              FROM issues WHERE project_id = ?1",
         )?;
         let rows = stmt.query_map(
@@ -276,6 +318,7 @@ pub(crate) fn export_project_subtree_via_tx(
         schema_version: SNAPSHOT_SCHEMA_VERSION,
         exported_at: chrono::Utc::now(),
         projects: vec![project],
+        members,
         statuses,
         labels,
         issues,
@@ -320,6 +363,7 @@ pub(crate) fn export_issue_subtree_via_tx(
         schema_version: SNAPSHOT_SCHEMA_VERSION,
         exported_at: chrono::Utc::now(),
         projects: Vec::new(),
+        members: Vec::new(),
         statuses: Vec::new(),
         labels: Vec::new(),
         issues: vec![issue],
@@ -342,6 +386,7 @@ pub(crate) fn export_status_row(
         schema_version: SNAPSHOT_SCHEMA_VERSION,
         exported_at: chrono::Utc::now(),
         projects: Vec::new(),
+        members: Vec::new(),
         statuses: vec![status],
         labels: Vec::new(),
         issues: Vec::new(),
@@ -363,6 +408,7 @@ pub(crate) fn export_project_statuses(
         schema_version: SNAPSHOT_SCHEMA_VERSION,
         exported_at: chrono::Utc::now(),
         projects: Vec::new(),
+        members: Vec::new(),
         statuses,
         labels: Vec::new(),
         issues: Vec::new(),
@@ -407,9 +453,50 @@ pub(crate) fn export_label_subtree_via_tx(
         schema_version: SNAPSHOT_SCHEMA_VERSION,
         exported_at: chrono::Utc::now(),
         projects: Vec::new(),
+        members: Vec::new(),
         statuses: Vec::new(),
         labels: vec![label],
         issues: Vec::new(),
         issue_labels,
+    })
+}
+
+/// Capture the member row + every issue in the member's project whose
+/// `assignee_id` references it. Used to build the inverse of `DeleteMember` so
+/// undo restores the member AND re-applies the assignments that the
+/// `ON DELETE SET NULL` foreign key cleared.
+pub(crate) fn export_member_subtree(
+    tx: &Transaction<'_>,
+    member_id: uuid::Uuid,
+) -> Result<crate::snapshot::WorkspaceSnapshot> {
+    use crate::snapshot::{SNAPSHOT_SCHEMA_VERSION, WorkspaceSnapshot};
+
+    let member = crate::store::read::members::by_id_via_tx(tx, member_id)?;
+
+    let mut issues = Vec::new();
+    {
+        let mut stmt = tx.prepare(
+            "SELECT id,project_id,seq,identifier,title,description,status_id,priority,
+                    due_date,sort_key,created_at,updated_at,assignee_id
+             FROM issues WHERE assignee_id = ?1",
+        )?;
+        let rows = stmt.query_map(
+            params![member_id.to_string()],
+            crate::store::read::issues::row_to_issue,
+        )?;
+        for r in rows {
+            issues.push(r?);
+        }
+    }
+
+    Ok(WorkspaceSnapshot {
+        schema_version: SNAPSHOT_SCHEMA_VERSION,
+        exported_at: chrono::Utc::now(),
+        projects: Vec::new(),
+        members: vec![member],
+        statuses: Vec::new(),
+        labels: Vec::new(),
+        issues,
+        issue_labels: Vec::new(),
     })
 }

--- a/crates/kanban-core/src/error.rs
+++ b/crates/kanban-core/src/error.rs
@@ -44,6 +44,7 @@ pub enum EntityKind {
     Issue,
     Label,
     Status,
+    Member,
 }
 
 impl std::fmt::Display for EntityKind {
@@ -53,6 +54,7 @@ impl std::fmt::Display for EntityKind {
             EntityKind::Issue => f.write_str("Issue"),
             EntityKind::Label => f.write_str("Label"),
             EntityKind::Status => f.write_str("Status"),
+            EntityKind::Member => f.write_str("Member"),
         }
     }
 }

--- a/crates/kanban-core/src/lib.rs
+++ b/crates/kanban-core/src/lib.rs
@@ -20,6 +20,6 @@ pub use operation::{Operation, OperationOutcome};
 pub use snapshot::{IssueLabelLink, SNAPSHOT_SCHEMA_VERSION, WorkspaceSnapshot};
 pub use time::{Clock, FixedClock, SystemClock, system_clock};
 pub use types::{
-    ActivityEntry, Issue, Label, Priority, Project, ProjectStatus, Status, StatusCategory,
+    ActivityEntry, Issue, Label, Member, Priority, Project, ProjectStatus, Status, StatusCategory,
 };
 pub use workspace::{Workspace, WorkspacePath};

--- a/crates/kanban-core/src/operation.rs
+++ b/crates/kanban-core/src/operation.rs
@@ -27,6 +27,10 @@ pub enum Operation {
     DeleteStatus(DeleteStatus),
     ReorderStatus(ReorderStatus),
 
+    CreateMember(CreateMember),
+    UpdateMember(UpdateMember),
+    DeleteMember(DeleteMember),
+
     ImportSnapshot(ImportSnapshot),
 }
 
@@ -183,6 +187,31 @@ pub struct DeleteStatus {
 pub struct ReorderStatus {
     pub id: Uuid,
     pub new_position: i64,
+}
+
+// ----- Member ops -----
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CreateMember {
+    pub id: Uuid,
+    pub project_id: Uuid,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UpdateMember {
+    pub id: Uuid,
+    pub patch: MemberPatch,
+}
+
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct MemberPatch {
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DeleteMember {
+    pub id: Uuid,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/kanban-core/src/operation.rs
+++ b/crates/kanban-core/src/operation.rs
@@ -97,6 +97,8 @@ pub enum IssueFieldChange {
     Status(Uuid),
     Priority(Priority),
     DueDate(Option<NaiveDate>),
+    /// The assigned member, or `None` to unassign.
+    Assignee(Option<Uuid>),
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/kanban-core/src/snapshot.rs
+++ b/crates/kanban-core/src/snapshot.rs
@@ -1,15 +1,16 @@
-use crate::types::{Issue, Label, Project, Status};
+use crate::types::{Issue, Label, Member, Project, Status};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-pub const SNAPSHOT_SCHEMA_VERSION: u32 = 1;
+pub const SNAPSHOT_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WorkspaceSnapshot {
     pub schema_version: u32,
     pub exported_at: DateTime<Utc>,
     pub projects: Vec<Project>,
+    pub members: Vec<Member>,
     pub statuses: Vec<Status>,
     pub issues: Vec<Issue>,
     pub labels: Vec<Label>,
@@ -33,6 +34,7 @@ mod tests {
             schema_version: SNAPSHOT_SCHEMA_VERSION,
             exported_at: Utc::now(),
             projects: vec![],
+            members: vec![],
             statuses: vec![],
             issues: vec![],
             labels: vec![],
@@ -40,6 +42,6 @@ mod tests {
         };
         let s = serde_json::to_string(&snap).unwrap();
         let back: WorkspaceSnapshot = serde_json::from_str(&s).unwrap();
-        assert_eq!(back.schema_version, 1);
+        assert_eq!(back.schema_version, SNAPSHOT_SCHEMA_VERSION);
     }
 }

--- a/crates/kanban-core/src/store/migrations.rs
+++ b/crates/kanban-core/src/store/migrations.rs
@@ -9,6 +9,11 @@ const MIGRATIONS: &[(i64, &str, &str)] = &[
         "workspace_settings",
         include_str!("../../migrations/0002_workspace_settings.sql"),
     ),
+    (
+        3,
+        "members",
+        include_str!("../../migrations/0003_members.sql"),
+    ),
 ];
 
 pub fn run(conn: &mut Connection) -> Result<()> {
@@ -87,6 +92,7 @@ mod tests {
             "issue_search",
             "issues",
             "labels",
+            "members",
             "operation_log",
             "projects",
             "schema_migrations",
@@ -108,7 +114,7 @@ mod tests {
         let count: i64 = conn
             .query_row("SELECT COUNT(*) FROM schema_migrations", [], |r| r.get(0))
             .unwrap();
-        assert_eq!(count, 2);
+        assert_eq!(count, 3);
     }
 
     #[test]

--- a/crates/kanban-core/src/store/read/issues.rs
+++ b/crates/kanban-core/src/store/read/issues.rs
@@ -39,11 +39,11 @@ pub(crate) fn list(conn: &Connection, filter: &crate::query::IssueFilter) -> Res
 }
 
 const ISSUE_SELECT: &str = "
-SELECT id,project_id,seq,identifier,title,description,status_id,priority,due_date,sort_key,created_at,updated_at
+SELECT id,project_id,seq,identifier,title,description,status_id,priority,due_date,sort_key,created_at,updated_at,assignee_id
 FROM issues WHERE id = ?1";
 
 pub(crate) const ISSUE_LIST_BASE: &str = "
-SELECT id,project_id,seq,identifier,title,description,status_id,priority,due_date,sort_key,created_at,updated_at
+SELECT id,project_id,seq,identifier,title,description,status_id,priority,due_date,sort_key,created_at,updated_at,assignee_id
 FROM issues";
 
 /// Same projection as [`ISSUE_LIST_BASE`] but with all columns qualified by
@@ -51,7 +51,7 @@ FROM issues";
 /// table also exposes `title`/`description`, making unqualified references
 /// ambiguous.
 pub(crate) const ISSUE_LIST_BASE_QUALIFIED: &str = "
-SELECT issues.id,issues.project_id,issues.seq,issues.identifier,issues.title,issues.description,issues.status_id,issues.priority,issues.due_date,issues.sort_key,issues.created_at,issues.updated_at
+SELECT issues.id,issues.project_id,issues.seq,issues.identifier,issues.title,issues.description,issues.status_id,issues.priority,issues.due_date,issues.sort_key,issues.created_at,issues.updated_at,issues.assignee_id
 FROM issues";
 
 pub(crate) fn row_to_issue(r: &rusqlite::Row<'_>) -> rusqlite::Result<Issue> {
@@ -62,6 +62,7 @@ pub(crate) fn row_to_issue(r: &rusqlite::Row<'_>) -> rusqlite::Result<Issue> {
     let due_s: Option<String> = r.get(8)?;
     let created_s: String = r.get(10)?;
     let updated_s: String = r.get(11)?;
+    let assignee_s: Option<String> = r.get(12)?;
     Ok(Issue {
         id: Uuid::from_str(&id).map_err(|e| {
             rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
@@ -89,6 +90,17 @@ pub(crate) fn row_to_issue(r: &rusqlite::Row<'_>) -> rusqlite::Result<Issue> {
         due_date: due_s
             .map(|s| {
                 NaiveDate::parse_from_str(&s, "%Y-%m-%d").map_err(|e| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        0,
+                        rusqlite::types::Type::Text,
+                        Box::new(e),
+                    )
+                })
+            })
+            .transpose()?,
+        assignee_id: assignee_s
+            .map(|s| {
+                Uuid::from_str(&s).map_err(|e| {
                     rusqlite::Error::FromSqlConversionFailure(
                         0,
                         rusqlite::types::Type::Text,

--- a/crates/kanban-core/src/store/read/members.rs
+++ b/crates/kanban-core/src/store/read/members.rs
@@ -1,0 +1,72 @@
+use crate::error::{Error, Result};
+use crate::types::Member;
+use chrono::DateTime;
+use rusqlite::{Connection, params};
+use std::str::FromStr;
+use uuid::Uuid;
+
+pub(crate) fn for_project(conn: &Connection, project_id: Uuid) -> Result<Vec<Member>> {
+    let mut stmt = conn.prepare(
+        "SELECT id,project_id,name,created_at FROM members WHERE project_id = ?1 ORDER BY name",
+    )?;
+    let rows = stmt.query_map(params![project_id.to_string()], row_to_member)?;
+    let mut out = Vec::new();
+    for r in rows {
+        out.push(r?);
+    }
+    Ok(out)
+}
+
+pub(crate) fn for_project_via_tx(
+    tx: &rusqlite::Transaction<'_>,
+    project_id: Uuid,
+) -> Result<Vec<Member>> {
+    let mut stmt = tx.prepare(
+        "SELECT id,project_id,name,created_at FROM members WHERE project_id = ?1 ORDER BY name",
+    )?;
+    let rows = stmt.query_map(params![project_id.to_string()], row_to_member)?;
+    let mut out = Vec::new();
+    for r in rows {
+        out.push(r?);
+    }
+    Ok(out)
+}
+
+pub(crate) fn by_id_via_tx(tx: &rusqlite::Transaction<'_>, id: Uuid) -> Result<Member> {
+    tx.query_row(
+        "SELECT id,project_id,name,created_at FROM members WHERE id = ?1",
+        params![id.to_string()],
+        row_to_member,
+    )
+    .map_err(|e| match e {
+        rusqlite::Error::QueryReturnedNoRows => Error::NotFound {
+            kind: crate::EntityKind::Member,
+            id: id.to_string(),
+        },
+        other => other.into(),
+    })
+}
+
+fn row_to_member(r: &rusqlite::Row<'_>) -> rusqlite::Result<Member> {
+    let id: String = r.get(0)?;
+    let pid: String = r.get(1)?;
+    let created_s: String = r.get(3)?;
+    Ok(Member {
+        id: Uuid::from_str(&id).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
+        })?,
+        project_id: Uuid::from_str(&pid).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
+        })?,
+        name: r.get(2)?,
+        created_at: DateTime::parse_from_rfc3339(&created_s)
+            .map_err(|e| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    0,
+                    rusqlite::types::Type::Text,
+                    Box::new(e),
+                )
+            })?
+            .with_timezone(&chrono::Utc),
+    })
+}

--- a/crates/kanban-core/src/store/read/mod.rs
+++ b/crates/kanban-core/src/store/read/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod issues;
 pub(crate) mod labels;
 pub(crate) mod log;
+pub(crate) mod members;
 pub(crate) mod projects;
 pub(crate) mod search;
 pub(crate) mod statuses;

--- a/crates/kanban-core/src/store/write/issues.rs
+++ b/crates/kanban-core/src/store/write/issues.rs
@@ -69,6 +69,7 @@ pub(crate) fn insert(
         status_id,
         priority,
         due_date,
+        assignee_id: None,
         sort_key,
         created_at: now,
         updated_at: now,

--- a/crates/kanban-core/src/store/write/members.rs
+++ b/crates/kanban-core/src/store/write/members.rs
@@ -1,0 +1,38 @@
+use crate::error::Result;
+use chrono::{DateTime, Utc};
+use rusqlite::{Transaction, params};
+use uuid::Uuid;
+
+pub(crate) fn insert(
+    tx: &Transaction<'_>,
+    id: Uuid,
+    project_id: Uuid,
+    name: &str,
+    created_at: DateTime<Utc>,
+) -> Result<()> {
+    tx.execute(
+        "INSERT INTO members(id,project_id,name,created_at) VALUES (?1,?2,?3,?4)",
+        params![
+            id.to_string(),
+            project_id.to_string(),
+            name,
+            created_at.to_rfc3339(),
+        ],
+    )?;
+    Ok(())
+}
+
+pub(crate) fn update_fields(tx: &Transaction<'_>, id: Uuid, name: Option<&str>) -> Result<()> {
+    if let Some(v) = name {
+        tx.execute(
+            "UPDATE members SET name = ?1 WHERE id = ?2",
+            params![v, id.to_string()],
+        )?;
+    }
+    Ok(())
+}
+
+pub(crate) fn delete(tx: &Transaction<'_>, id: Uuid) -> Result<()> {
+    tx.execute("DELETE FROM members WHERE id = ?1", params![id.to_string()])?;
+    Ok(())
+}

--- a/crates/kanban-core/src/store/write/mod.rs
+++ b/crates/kanban-core/src/store/write/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod issues;
 pub(crate) mod labels;
+pub(crate) mod members;
 pub(crate) mod operation_log;
 pub(crate) mod projects;
 pub(crate) mod statuses;

--- a/crates/kanban-core/src/types.rs
+++ b/crates/kanban-core/src/types.rs
@@ -134,6 +134,9 @@ pub struct Issue {
     pub status_id: Uuid,
     pub priority: Priority,
     pub due_date: Option<NaiveDate>,
+    /// Optional single assignee (a project [`Member`]). Nulled by the DB
+    /// (`ON DELETE SET NULL`) when the referenced member is deleted.
+    pub assignee_id: Option<Uuid>,
     /// Stored losslessly as the `f64`'s `u64` bit pattern in JSON so snapshots
     /// (`WorkspaceSnapshot`) round-trip bit-exactly through `ImportSnapshot`.
     /// Mirrors the same wrapper applied to `ReorderIssue::new_sort_key`.
@@ -149,6 +152,14 @@ pub struct Label {
     pub project_id: Uuid,
     pub name: String,
     pub color: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Member {
+    pub id: Uuid,
+    pub project_id: Uuid,
+    pub name: String,
+    pub created_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/kanban-core/src/workspace.rs
+++ b/crates/kanban-core/src/workspace.rs
@@ -117,6 +117,18 @@ impl Workspace {
         crate::store::read::labels::for_project(&self.conn, project_id)
     }
 
+    /// List all members for `project_id` ordered by name.
+    ///
+    /// # Errors
+    ///
+    /// Returns a database error if the read fails.
+    pub fn query_members_for_project(
+        &self,
+        project_id: uuid::Uuid,
+    ) -> crate::error::Result<Vec<crate::types::Member>> {
+        crate::store::read::members::for_project(&self.conn, project_id)
+    }
+
     /// List all labels attached to `issue_id` ordered by name.
     ///
     /// # Errors
@@ -322,9 +334,11 @@ impl Workspace {
 
         let projects = crate::store::read::projects::list_all(&self.conn)?;
 
+        let mut members = Vec::new();
         let mut statuses = Vec::new();
         let mut labels = Vec::new();
         for p in &projects {
+            members.extend(crate::store::read::members::for_project(&self.conn, p.id)?);
             statuses.extend(crate::store::read::statuses::for_project(&self.conn, p.id)?);
             labels.extend(crate::store::read::labels::for_project(&self.conn, p.id)?);
         }
@@ -361,6 +375,7 @@ impl Workspace {
             schema_version: SNAPSHOT_SCHEMA_VERSION,
             exported_at: chrono::Utc::now(),
             projects,
+            members,
             statuses,
             issues,
             labels,
@@ -395,7 +410,7 @@ mod tests {
             .conn
             .query_row("SELECT COUNT(*) FROM schema_migrations", [], |r| r.get(0))
             .unwrap();
-        assert_eq!(count, 2);
+        assert_eq!(count, 3);
     }
 
     #[test]

--- a/crates/kanban-core/tests/apply_members.rs
+++ b/crates/kanban-core/tests/apply_members.rs
@@ -2,10 +2,33 @@
 #![allow(clippy::panic)]
 
 use kanban_core::operation::{
-    ConflictPolicy, CreateMember, CreateProject, DeleteMember, ImportSnapshot, MemberPatch,
-    Operation, UpdateMember,
+    AttachLabel, ConflictPolicy, CreateIssue, CreateLabel, CreateMember, CreateProject,
+    DeleteMember, ImportSnapshot, IssueFieldChange, MemberPatch, Operation, UpdateIssueField,
+    UpdateMember,
 };
+use kanban_core::types::Priority;
 use kanban_core::{Workspace, new_id};
+
+fn make_issue(ws: &mut Workspace, pid: uuid::Uuid) -> uuid::Uuid {
+    let id = new_id();
+    let status_id = ws.query_statuses_for_project(pid).unwrap()[0].id;
+    ws.apply(Operation::CreateIssue(CreateIssue {
+        id,
+        project_id: pid,
+        title: "task".into(),
+        description: None,
+        status_id,
+        priority: Priority::Medium,
+        due_date: None,
+        label_ids: vec![],
+    }))
+    .unwrap();
+    id
+}
+
+fn assignee_of(ws: &Workspace, id: uuid::Uuid) -> Option<uuid::Uuid> {
+    ws.query_issue_by_id(id).unwrap().assignee_id
+}
 
 fn fresh_with_project() -> (Workspace, uuid::Uuid) {
     let mut ws = Workspace::open_in_memory().unwrap();
@@ -173,6 +196,131 @@ fn snapshot_round_trips_member() {
     let members = fresh.query_members_for_project(pid).unwrap();
     assert_eq!(members.len(), 1);
     assert_eq!(members[0].name, "Grace");
+}
+
+#[test]
+fn assign_and_unassign_issue() {
+    let (mut ws, pid) = fresh_with_project();
+    let member = new_id();
+    ws.apply(Operation::CreateMember(CreateMember {
+        id: member,
+        project_id: pid,
+        name: "Ada".into(),
+    }))
+    .unwrap();
+    let issue = make_issue(&mut ws, pid);
+
+    ws.apply(Operation::UpdateIssueField(UpdateIssueField {
+        id: issue,
+        change: IssueFieldChange::Assignee(Some(member)),
+    }))
+    .unwrap();
+    assert_eq!(assignee_of(&ws, issue), Some(member));
+
+    ws.apply(Operation::UpdateIssueField(UpdateIssueField {
+        id: issue,
+        change: IssueFieldChange::Assignee(None),
+    }))
+    .unwrap();
+    assert_eq!(assignee_of(&ws, issue), None);
+}
+
+#[test]
+fn assign_foreign_member_rejected() {
+    let (mut ws, pid) = fresh_with_project();
+    let issue = make_issue(&mut ws, pid);
+    // A member in a DIFFERENT project must not be assignable.
+    let other = new_id();
+    ws.apply(Operation::CreateProject(CreateProject {
+        id: other,
+        name: "O".into(),
+        prefix: "OTH".into(),
+        description: None,
+        icon: None,
+    }))
+    .unwrap();
+    let foreign = new_id();
+    ws.apply(Operation::CreateMember(CreateMember {
+        id: foreign,
+        project_id: other,
+        name: "Bob".into(),
+    }))
+    .unwrap();
+    let err = ws
+        .apply(Operation::UpdateIssueField(UpdateIssueField {
+            id: issue,
+            change: IssueFieldChange::Assignee(Some(foreign)),
+        }))
+        .unwrap_err();
+    assert!(err.to_string().to_lowercase().contains("project"), "{err}");
+}
+
+#[test]
+fn assign_undo_restores_prior_assignee() {
+    let (mut ws, pid) = fresh_with_project();
+    let m1 = new_id();
+    ws.apply(Operation::CreateMember(CreateMember {
+        id: m1,
+        project_id: pid,
+        name: "Ada".into(),
+    }))
+    .unwrap();
+    let issue = make_issue(&mut ws, pid);
+    ws.apply(Operation::UpdateIssueField(UpdateIssueField {
+        id: issue,
+        change: IssueFieldChange::Assignee(Some(m1)),
+    }))
+    .unwrap();
+    ws.apply(Operation::UpdateIssueField(UpdateIssueField {
+        id: issue,
+        change: IssueFieldChange::Assignee(None),
+    }))
+    .unwrap();
+    ws.undo().unwrap(); // undo the unassign -> back to m1
+    assert_eq!(assignee_of(&ws, issue), Some(m1));
+}
+
+#[test]
+fn delete_member_undo_restores_assignment_and_labels() {
+    let (mut ws, pid) = fresh_with_project();
+    let member = new_id();
+    ws.apply(Operation::CreateMember(CreateMember {
+        id: member,
+        project_id: pid,
+        name: "Ada".into(),
+    }))
+    .unwrap();
+    let issue = make_issue(&mut ws, pid);
+    // Attach a label to the assigned issue (exercises the issue_labels capture).
+    let label = new_id();
+    ws.apply(Operation::CreateLabel(CreateLabel {
+        id: label,
+        project_id: pid,
+        name: "bug".into(),
+        color: "#ff0000".into(),
+    }))
+    .unwrap();
+    ws.apply(Operation::AttachLabel(AttachLabel {
+        issue_id: issue,
+        label_id: label,
+    }))
+    .unwrap();
+    ws.apply(Operation::UpdateIssueField(UpdateIssueField {
+        id: issue,
+        change: IssueFieldChange::Assignee(Some(member)),
+    }))
+    .unwrap();
+
+    // Deleting the member nulls the assignment (ON DELETE SET NULL).
+    ws.apply(Operation::DeleteMember(DeleteMember { id: member }))
+        .unwrap();
+    assert_eq!(assignee_of(&ws, issue), None);
+
+    // Undo restores the member, the assignment, AND the label attachment.
+    ws.undo().unwrap();
+    assert_eq!(ws.query_members_for_project(pid).unwrap().len(), 1);
+    assert_eq!(assignee_of(&ws, issue), Some(member));
+    assert_eq!(ws.query_labels_for_issue(issue).unwrap().len(), 1);
 }
 
 #[test]

--- a/crates/kanban-core/tests/apply_members.rs
+++ b/crates/kanban-core/tests/apply_members.rs
@@ -1,0 +1,217 @@
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::panic)]
+
+use kanban_core::operation::{
+    ConflictPolicy, CreateMember, CreateProject, DeleteMember, ImportSnapshot, MemberPatch,
+    Operation, UpdateMember,
+};
+use kanban_core::{Workspace, new_id};
+
+fn fresh_with_project() -> (Workspace, uuid::Uuid) {
+    let mut ws = Workspace::open_in_memory().unwrap();
+    let pid = new_id();
+    ws.apply(Operation::CreateProject(CreateProject {
+        id: pid,
+        name: "M".into(),
+        prefix: "MBR".into(),
+        description: None,
+        icon: None,
+    }))
+    .unwrap();
+    (ws, pid)
+}
+
+#[test]
+fn create_member_inserts() {
+    let (mut ws, pid) = fresh_with_project();
+    let id = new_id();
+    ws.apply(Operation::CreateMember(CreateMember {
+        id,
+        project_id: pid,
+        name: "Ada".into(),
+    }))
+    .unwrap();
+    let members = ws.query_members_for_project(pid).unwrap();
+    assert_eq!(members.len(), 1);
+    assert_eq!(members[0].name, "Ada");
+    assert_eq!(members[0].id, id);
+    assert_eq!(members[0].project_id, pid);
+}
+
+#[test]
+fn create_member_rejects_empty_name() {
+    let (mut ws, pid) = fresh_with_project();
+    let err = ws
+        .apply(Operation::CreateMember(CreateMember {
+            id: new_id(),
+            project_id: pid,
+            name: String::new(),
+        }))
+        .unwrap_err();
+    assert!(err.to_string().contains("name"), "{err}");
+}
+
+#[test]
+fn create_member_rejects_duplicate_name_per_project() {
+    let (mut ws, pid) = fresh_with_project();
+    ws.apply(Operation::CreateMember(CreateMember {
+        id: new_id(),
+        project_id: pid,
+        name: "dup".into(),
+    }))
+    .unwrap();
+    let err = ws
+        .apply(Operation::CreateMember(CreateMember {
+            id: new_id(),
+            project_id: pid,
+            name: "dup".into(),
+        }))
+        .unwrap_err();
+    assert!(err.to_string().to_lowercase().contains("conflict"), "{err}");
+}
+
+#[test]
+fn update_member_renames() {
+    let (mut ws, pid) = fresh_with_project();
+    let id = new_id();
+    ws.apply(Operation::CreateMember(CreateMember {
+        id,
+        project_id: pid,
+        name: "old".into(),
+    }))
+    .unwrap();
+    ws.apply(Operation::UpdateMember(UpdateMember {
+        id,
+        patch: MemberPatch {
+            name: Some("new".into()),
+        },
+    }))
+    .unwrap();
+    let members = ws.query_members_for_project(pid).unwrap();
+    assert_eq!(members[0].name, "new");
+}
+
+#[test]
+fn create_member_undo_removes_it() {
+    let (mut ws, pid) = fresh_with_project();
+    let id = new_id();
+    ws.apply(Operation::CreateMember(CreateMember {
+        id,
+        project_id: pid,
+        name: "temp".into(),
+    }))
+    .unwrap();
+    assert_eq!(ws.query_members_for_project(pid).unwrap().len(), 1);
+    ws.undo().unwrap();
+    assert!(ws.query_members_for_project(pid).unwrap().is_empty());
+}
+
+#[test]
+fn update_member_undo_restores_name() {
+    let (mut ws, pid) = fresh_with_project();
+    let id = new_id();
+    ws.apply(Operation::CreateMember(CreateMember {
+        id,
+        project_id: pid,
+        name: "original".into(),
+    }))
+    .unwrap();
+    ws.apply(Operation::UpdateMember(UpdateMember {
+        id,
+        patch: MemberPatch {
+            name: Some("changed".into()),
+        },
+    }))
+    .unwrap();
+    ws.undo().unwrap();
+    let members = ws.query_members_for_project(pid).unwrap();
+    assert_eq!(members[0].name, "original");
+}
+
+#[test]
+fn delete_member_undo_restores_member() {
+    let (mut ws, pid) = fresh_with_project();
+    let id = new_id();
+    ws.apply(Operation::CreateMember(CreateMember {
+        id,
+        project_id: pid,
+        name: "kept".into(),
+    }))
+    .unwrap();
+    ws.apply(Operation::DeleteMember(DeleteMember { id }))
+        .unwrap();
+    assert!(ws.query_members_for_project(pid).unwrap().is_empty());
+    ws.undo().unwrap();
+    let members = ws.query_members_for_project(pid).unwrap();
+    assert_eq!(members.len(), 1);
+    assert_eq!(members[0].id, id);
+    assert_eq!(members[0].name, "kept");
+}
+
+#[test]
+fn snapshot_round_trips_member() {
+    let (mut ws, pid) = fresh_with_project();
+    let id = new_id();
+    ws.apply(Operation::CreateMember(CreateMember {
+        id,
+        project_id: pid,
+        name: "Grace".into(),
+    }))
+    .unwrap();
+
+    let snap = ws.export_snapshot().unwrap();
+    assert!(snap.members.iter().any(|m| m.id == id && m.name == "Grace"));
+
+    // Import into a fresh workspace; the member must come across.
+    let mut fresh = Workspace::open_in_memory().unwrap();
+    fresh
+        .apply(Operation::ImportSnapshot(ImportSnapshot {
+            snapshot: snap,
+            policy: ConflictPolicy::Overwrite,
+        }))
+        .unwrap();
+    let members = fresh.query_members_for_project(pid).unwrap();
+    assert_eq!(members.len(), 1);
+    assert_eq!(members[0].name, "Grace");
+}
+
+#[test]
+fn migration_0003_applied_and_issue_allows_null_assignee() {
+    let ws = Workspace::open_in_memory().unwrap();
+    let conn = ws._conn_for_integration_tests();
+    let has_v3: bool = conn
+        .query_row(
+            "SELECT 1 FROM schema_migrations WHERE version = 3",
+            [],
+            |_| Ok(true),
+        )
+        .unwrap();
+    assert!(has_v3);
+
+    // Insert a project/status/issue with a NULL assignee_id directly to prove
+    // the column exists and is nullable.
+    conn.execute(
+        "INSERT INTO projects(id,name,prefix,status,next_seq,created_at,updated_at)
+         VALUES('p','P','PPP','active',1,'2026-01-01T00:00:00Z','2026-01-01T00:00:00Z')",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO statuses(id,project_id,name,category,color,position)
+         VALUES('s','p','Todo','unstarted','#000000',0)",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO issues(id,project_id,seq,identifier,title,description,status_id,priority,due_date,sort_key,created_at,updated_at,assignee_id)
+         VALUES('i','p',1,'PPP-1','t',NULL,'s','none',NULL,1.0,'2026-01-01T00:00:00Z','2026-01-01T00:00:00Z',NULL)",
+        [],
+    )
+    .unwrap();
+    let assignee: Option<String> = conn
+        .query_row("SELECT assignee_id FROM issues WHERE id = 'i'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert!(assignee.is_none());
+}

--- a/crates/kanban-core/tests/snapshot_export.rs
+++ b/crates/kanban-core/tests/snapshot_export.rs
@@ -29,7 +29,7 @@ fn export_snapshot_contains_all_entities() {
     }))
     .unwrap();
     let snap = ws.export_snapshot().unwrap();
-    assert_eq!(snap.schema_version, 1);
+    assert_eq!(snap.schema_version, kanban_core::SNAPSHOT_SCHEMA_VERSION);
     assert_eq!(snap.projects.len(), 1);
     assert_eq!(snap.statuses.len(), 7);
     assert_eq!(snap.issues.len(), 1);

--- a/crates/kanban-tauri/src/commands.rs
+++ b/crates/kanban-tauri/src/commands.rs
@@ -13,7 +13,7 @@ use kanban_core::operation::Operation;
 use kanban_core::query::IssueFilter;
 use kanban_core::types::Project;
 
-use crate::dto::{IssueDto, LabelDto, ProjectDto, StatusDto};
+use crate::dto::{IssueDto, LabelDto, MemberDto, ProjectDto, StatusDto};
 use crate::error::ApiError;
 use crate::settings::{Settings, ThemeChoice};
 use crate::state::AppState;
@@ -127,6 +127,24 @@ pub fn list_labels_inner(ws: &Workspace, prefix: &str) -> Result<Vec<LabelDto>, 
         .query_labels_for_project(project.id)?
         .into_iter()
         .map(LabelDto::from)
+        .collect())
+}
+
+/// List the members of the project identified by `prefix`.
+///
+/// An unknown prefix yields an empty list (not an error).
+///
+/// # Errors
+///
+/// Returns an error if the underlying query fails.
+pub fn list_members_inner(ws: &Workspace, prefix: &str) -> Result<Vec<MemberDto>, ApiError> {
+    let Some(project) = project_by_prefix(ws, prefix)? else {
+        return Ok(Vec::new());
+    };
+    Ok(ws
+        .query_members_for_project(project.id)?
+        .into_iter()
+        .map(MemberDto::from)
         .collect())
 }
 
@@ -266,6 +284,27 @@ pub async fn list_labels(
     tokio::task::spawn_blocking(move || {
         let guard = lock_workspace(&ws)?;
         list_labels_inner(&guard, &project)
+    })
+    .await
+    .map_err(|e| join_error(&e))?
+}
+
+/// Tauri command: list the members of the project identified by `project` (its prefix).
+///
+/// # Errors
+///
+/// Returns an error if the workspace mutex is poisoned, the blocking task fails
+/// to join, or the underlying query fails.
+#[tauri::command]
+#[specta::specta]
+pub async fn list_members(
+    state: tauri::State<'_, AppState>,
+    project: String,
+) -> Result<Vec<MemberDto>, ApiError> {
+    let ws = std::sync::Arc::clone(&state.workspace);
+    tokio::task::spawn_blocking(move || {
+        let guard = lock_workspace(&ws)?;
+        list_members_inner(&guard, &project)
     })
     .await
     .map_err(|e| join_error(&e))?

--- a/crates/kanban-tauri/src/dto.rs
+++ b/crates/kanban-tauri/src/dto.rs
@@ -5,7 +5,7 @@
 //! ids, timestamps, dates, and enums as plain strings, and `sort_key` as a
 //! plain `f64`, so the generated TypeScript bindings stay simple.
 
-use kanban_core::types::{Issue, Label, Project, Status};
+use kanban_core::types::{Issue, Label, Member, Project, Status};
 use serde::{Deserialize, Serialize};
 use specta::Type;
 
@@ -70,6 +70,7 @@ pub struct IssueDto {
     pub status_id: String,
     pub priority: String,
     pub due_date: Option<String>,
+    pub assignee_id: Option<String>,
     pub sort_key: f64,
     pub created_at: String,
     pub updated_at: String,
@@ -88,6 +89,7 @@ impl From<Issue> for IssueDto {
             status_id: i.status_id.to_string(),
             priority: i.priority.as_str().to_owned(),
             due_date: i.due_date.map(|d| d.to_string()),
+            assignee_id: i.assignee_id.map(|a| a.to_string()),
             sort_key: i.sort_key,
             created_at: i.created_at.to_rfc3339(),
             updated_at: i.updated_at.to_rfc3339(),
@@ -111,6 +113,23 @@ impl From<Label> for LabelDto {
             project_id: l.project_id.to_string(),
             name: l.name,
             color: l.color,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct MemberDto {
+    pub id: String,
+    pub project_id: String,
+    pub name: String,
+}
+
+impl From<Member> for MemberDto {
+    fn from(m: Member) -> Self {
+        Self {
+            id: m.id.to_string(),
+            project_id: m.project_id.to_string(),
+            name: m.name,
         }
     }
 }

--- a/crates/kanban-tauri/src/error.rs
+++ b/crates/kanban-tauri/src/error.rs
@@ -31,6 +31,7 @@ impl From<kanban_core::Error> for ApiError {
                     EntityKind::Issue => "issue",
                     EntityKind::Label => "label",
                     EntityKind::Status => "status",
+                    EntityKind::Member => "member",
                 }
                 .to_string(),
                 key: id,

--- a/crates/kanban-tauri/src/lib.rs
+++ b/crates/kanban-tauri/src/lib.rs
@@ -19,6 +19,7 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
             commands::get_issue,
             commands::list_statuses,
             commands::list_labels,
+            commands::list_members,
             commands::get_settings,
             commands::update_settings,
             commands::apply,

--- a/docs/superpowers/plans/2026-06-06-kanban-v2-spec-6-members-assignees-plan.md
+++ b/docs/superpowers/plans/2026-06-06-kanban-v2-spec-6-members-assignees-plan.md
@@ -1,0 +1,76 @@
+# Kanban v2 — Spec #6 Members & Assignees Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]`.
+
+**Goal:** Per-project member directory + a single nullable assignee per issue, fully undoable, exposed in GUI + CLI.
+
+**Architecture:** New `members` table + `issues.assignee_id` (migration `0003`). New ops `CreateMember`/`UpdateMember`/`DeleteMember` mirror the label ops; assignment reuses `UpdateIssueField` via a new `IssueFieldChange::Assignee(Option<Uuid>)`. `WorkspaceSnapshot` gains `members` (schema v1→v2) so DeleteMember undo restores the member + its assignments. Tauri `apply` stays generic; `IssueDto` gains `assignee_id` + a `list_members` command (bindings regen).
+
+**Tech:** Rust 2024 / rusqlite; React 19 (Spec #2 stack). TDD.
+
+**Spec:** `docs/superpowers/specs/2026-06-06-kanban-v2-spec-6-members-assignees-design.md`
+
+## Conventions
+- Rust `~/.cargo/bin/cargo`; UI `cd ui && PATH="/opt/homebrew/bin:$PATH" npx --yes pnpm@9.12.0 <script>` (build fails on rollup arch → `… install --force`). Confirm REAL exit codes (`cmd; echo EXIT=$?`). Gates: cargo fmt/clippy(-D warnings)/test --workspace; ui typecheck/lint/test:unit/build. No `Co-Authored-By`. **Migrations are append-only — never edit 0001/0002.**
+
+---
+
+### Task 1: Migration 0003 + Member entity + member ops + snapshot extension (test-first)
+
+**Files:** new `crates/kanban-core/migrations/0003_members.sql`; `store/migrations.rs` (register); `types.rs` (`Member`, `Issue.assignee_id`); `store/read/members.rs` (new) + `store/read/issues.rs` (+assignee_id) + `store/read/mod.rs`; `store/write/members.rs` (new); `apply/members.rs` (new) + `apply/mod.rs` (wire); `snapshot.rs` (+`members`, bump `SNAPSHOT_SCHEMA_VERSION`→2); `apply/snapshot.rs` (`upsert_member`, `export_member_subtree`, project-subtree includes members, issue upsert/export includes `assignee_id`); `workspace.rs` (`query_members_for_project`); `tests/apply_members.rs` (new) + a migration test.
+
+- `0003_members.sql` per the design (members table + `ALTER TABLE issues ADD COLUMN assignee_id TEXT REFERENCES members(id) ON DELETE SET NULL`).
+- `Member { id, project_id, name, created_at }` (mirror `Label` derives, incl. serde). `Issue` gains `pub assignee_id: Option<Uuid>` — update every Issue construction (`row_to_issue` in read, snapshot import/export, any test builders) to include it.
+- Ops `CreateMember{id,project_id,name}`, `UpdateMember{id,patch:MemberPatch{name:Option<String>}}`, `DeleteMember{id}` — appliers + inverses (`inverse_of_create→Delete`, `inverse_of_update→prior name`, `inverse_of_delete→ImportSnapshot(export_member_subtree)`). `export_member_subtree(tx,id)`: snapshot with the member + the project's issues whose `assignee_id == id` (so undo restores assignments). Wire `dispatch`/`op_type_name`/`capture_inverse`.
+- `snapshot.rs`: add `pub members: Vec<Member>` to `WorkspaceSnapshot` + `members: vec![]` in its constructor; bump version. `apply/snapshot.rs::import` loops `args.snapshot.members` → `upsert_member`. Ensure the issue export/import SQL now reads/writes `assignee_id`.
+- Tests: migration applies (0003 in schema_migrations; assignee_id column exists, nullable); create/duplicate/rename; create-undo; update-undo; delete-undo-restores-member; **delete-member-with-assignment**: create member, assign an issue, delete member → issue.assignee_id becomes NULL; undo → member back AND issue re-assigned. Snapshot round-trip (export→import) preserves members + assignee_id.
+
+- [ ] Failing tests → implement → `cargo test -p kanban-core`, clippy, fmt green (EXIT=0). Commit `feat(core): add members table (0003), member ops, and snapshot members`.
+
+### Task 2: Assignment via `UpdateIssueField` (test-first)
+
+**Files:** `operation.rs` (`IssueFieldChange::Assignee(Option<Uuid>)`); `apply/issues.rs` (handle the new change + its inverse) — verify the member belongs to the issue's project else `Error::Conflict`; `tests/apply_issues.rs` (or apply_members.rs).
+
+- Add `Assignee(Option<Uuid>)` to `IssueFieldChange`. In the issue-field applier: on `Assignee(Some(m))`, check the member exists and `member.project_id == issue.project_id` (else `Error::Conflict("member is not in this issue's project")`); set `issues.assignee_id`. On `Assignee(None)` clear it. The inverse mirrors the existing field-change inverse (capture prior `assignee_id`).
+- Tests: assign sets assignee_id; unassign clears; assign-foreign-member rejected; assign-undo restores prior; reusing `UpdateIssueField`.
+
+- [ ] Failing tests → implement → `cargo test --workspace`, clippy, fmt green. Commit `feat(core): assign issues to a member via UpdateIssueField`.
+
+### Task 3: Tauri DTOs + list_members + bindings (test-first where practical)
+
+**Files:** `kanban-tauri/src/dto.rs` (`MemberDto`; `IssueDto.assignee_id: Option<String>`; optionally assignee name on the detail), `commands.rs` (`list_members(prefix)`; populate `assignee_id`), `lib.rs` (register command in `collect_commands!`), regenerate `ui/src/data/bindings.ts`.
+
+- `MemberDto{ id, project_id, name }` (specta `Type`, `From<Member>`). `IssueDto` gains `assignee_id: Option<String>` (set from `Issue.assignee_id`). `list_members` mirrors `list_labels`. Add `query_members_for_project` use.
+- Regenerate bindings (`cargo test -p kanban-tauri --test export_bindings`); fix any TS fixtures needing `assignee_id: null`. Commit the bindings.
+
+- [ ] `cargo test --workspace` + ui typecheck green; drift guard clean. Commit `feat(tauri): expose members and issue assignee to the GUI`.
+
+### Task 4: GUI — assignee picker + member management (test-first)
+
+**Files:** `ui/src/data/ops.ts` (`createMember`/`updateMember`/`deleteMember` + `change.assignee`), `ui/src/data/queries.ts` (`useMembers(prefix)` + `qk.members`), `ui/src/data/mutations.ts` (invalidate members/issues on member+assignee ops), `IssuePanel` (assignee `<select>` from `useMembers`), a member-management UI (e.g. in `ProjectRow`/a small dialog), tests.
+
+- `change.assignee(id: string | null)` → `{ field: "Assignee", value: id }`. Picker: `<select aria-label="Assignee">` with members + an "Unassigned" option → `updateIssueField(change.assignee(value||null))`.
+- Member management: add/rename/delete via the member ops.
+- Tests: builder shapes; assignee select dispatches `UpdateIssueField{Assignee}`; member add/rename/delete dispatch the ops. No `any`.
+
+- [ ] ui test:unit/typecheck/lint/build green (EXIT=0). Commit `feat(ui): assign issues to members and manage the member roster`.
+
+### Task 5: CLI — member subcommands + issue assign (test-first)
+
+**Files:** `kanban-cli/src/cmd/member.rs` (new) + `main.rs` (register); extend `cmd/issue.rs` with `assign`; snapshots.
+
+- `kanban member list|create|update|delete` (mirror `label.rs`). `kanban issue assign <identifier> <member-name>` and `--unassign` → `UpdateIssueField{Assignee}`. insta snapshots (happy + error: assign unknown/foreign member).
+
+- [ ] `cargo test --workspace` green. Commit `feat(cli): member subcommands and issue assign`.
+
+### Task 6: Acceptance + docs + PR
+
+- [ ] Full gates (cargo fmt/clippy/test --workspace; ui typecheck/lint/test:unit/build; bindings drift clean).
+- [ ] Update README/CLAUDE/DEVELOPMENT (members & assignees; note this is the last of the planned core features; MCP member tools / multi-assignee deferred).
+- [ ] superpowers:finishing-a-development-branch → PR to `dev`.
+
+## Self-review notes
+- 0003 is the only migration; 0001/0002 untouched. `assignee_id` nullable, FK `ON DELETE SET NULL`.
+- All ops undoable; DeleteMember inverse = `ImportSnapshot(member + assigned issues)`; assignment inverse via the existing field-change capture. Snapshot schema bumped to 2 and `members` round-tripped; `Issue.assignee_id` included in every snapshot path.
+- Verify each op/struct field set against `operation.rs`; verify the new `IssueFieldChange::Assignee` serde shape used by `ops.ts`/CLI.
+- The `Issue` struct gaining `assignee_id` ripples to every `Issue` construction — grep for them and update.

--- a/docs/superpowers/specs/2026-06-06-kanban-v2-spec-6-members-assignees-design.md
+++ b/docs/superpowers/specs/2026-06-06-kanban-v2-spec-6-members-assignees-design.md
@@ -1,0 +1,60 @@
+# Spec #6 — Members & Assignees
+
+**Date:** 2026-06-06
+**Builds on:** Spec #1–#5 (core + CLI + GUI + MCP + GUI completeness + custom statuses)
+**Roadmap:** E03 Members & Assignees — a per-project people directory; each issue may have one assignee.
+
+## Decisions (confirmed)
+- **Per-project members.** Each project owns its member roster (`members.project_id`). Only a project's own members can be assigned to its issues.
+- **Single assignee per issue.** Issues gain a nullable `assignee_id` referencing `members(id)`. (Multi-assignee is a later spec if ever needed.)
+
+## Migration `0003_members.sql` (the only new migration; append-only)
+```sql
+CREATE TABLE members (
+  id         TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  name       TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  UNIQUE (project_id, name)
+) STRICT;
+CREATE INDEX idx_members_project ON members(project_id);
+
+ALTER TABLE issues ADD COLUMN assignee_id TEXT REFERENCES members(id) ON DELETE SET NULL;
+```
+SQLite permits `ADD COLUMN` with a nullable `REFERENCES … ON DELETE SET NULL` (default NULL); `foreign_keys` is ON (`connection.rs`), so deleting a member nulls its issues' `assignee_id` at the DB level. Register `(3, "members", include_str!("…/0003_members.sql"))` in `store/migrations.rs`.
+
+## Operations (undoable, mirror the label/status ops)
+- `CreateMember { id, project_id, name }` — validate non-empty name; reject duplicate `(project_id, name)`; inverse `DeleteMember{id}`.
+- `UpdateMember { id, patch: MemberPatch { name? } }` — rename; inverse re-applies the prior name.
+- `DeleteMember { id }` — allowed (no guard); the DB nulls dependent `assignee_id`s. Inverse = `ImportSnapshot` capturing the member row **and** the issues that referenced it (so undo re-creates the member and restores those assignments).
+- **Assignment reuses `UpdateIssueField`**: add `IssueFieldChange::Assignee(Option<Uuid>)` — `Some(member_id)` assigns, `None` unassigns. Inverse is the existing field-change inverse (prior assignee). Validation: the member must belong to the issue's project (else `Error::Conflict`/`Validation`).
+
+## Snapshot changes (undo of DeleteMember)
+`WorkspaceSnapshot` gains `pub members: Vec<Member>`; bump `SNAPSHOT_SCHEMA_VERSION` 1 → 2. `apply/snapshot.rs::import` upserts members (a new `upsert_member`); the project-subtree export (used by delete-project inverse) includes members. The issue row now carries `assignee_id`, so the issues read/write used by snapshots must include it. A new `export_member_subtree(tx, member_id)` captures the member + the project's issues assigned to it.
+
+## Types / DTO / bridge
+- `types.rs`: new `Member { id: Uuid, project_id: Uuid, name: String, created_at: DateTime<Utc> }`. `Issue` gains `assignee_id: Option<Uuid>`.
+- `store/read`: `members::for_project` / `by_id_via_tx`; `Workspace::query_members_for_project(project_id)`. Issue reads include `assignee_id`.
+- Tauri: `MemberDto { id, project_id, name }`; a `list_members(prefix)` command; `IssueDto` gains `assignee_id: Option<String>` and `IssueDetailDto`/`get_issue` may include the resolved assignee name. Regenerate `bindings.ts` (drift-guarded). `apply` stays generic.
+- MCP: optional `list_members` / assignment surfacing — **deferred** to keep scope; note it.
+
+## GUI
+- Issue detail panel: an **assignee picker** (lists the project's members via `useMembers(prefix)`; selecting → `updateIssueField(change.assignee(memberId|null))`); show the current assignee.
+- A small **member management** affordance (e.g. in the project settings / sidebar or a panel): add/rename/delete members → `createMember`/`updateMember`/`deleteMember`.
+- Board card: optionally show an assignee initial/avatar (stretch).
+- `ops.ts`: `createMember`/`updateMember`/`deleteMember` builders + `change.assignee`. `mutations.ts`: invalidate a `qk.members(prefix)` key + issues on member/assignee ops.
+
+## CLI
+- `kanban member list|create|update|delete` (mirror `label`); `kanban issue assign <identifier> <member-name|--unassign>`.
+
+## Testing
+- Core: `tests/apply_members.rs` — create / duplicate / rename / delete-undo-restores-member-and-assignments / assign / unassign / assign-foreign-member-rejected; plus a migration test (0003 applies; assignee_id nullable). Snapshot round-trip includes members + assignee_id.
+- CLI: `member_cmds.rs` + an `issue assign` test (insta).
+- GUI: Vitest + RTL for the builders, assignee picker, member management.
+- All gates green; bindings drift accounted for (regenerated + committed).
+
+## Non-goals
+- Multi-assignee; member avatars/emails/auth; cross-project members; MCP member tools (later). 
+
+## Acceptance
+A user can, per project: add/rename/delete members; assign an issue to one member (or unassign); deleting a member unassigns their issues — every change undoable (undoing a member delete restores the member and its prior assignments).

--- a/ui/src/components/detail/AssigneePicker.tsx
+++ b/ui/src/components/detail/AssigneePicker.tsx
@@ -1,0 +1,102 @@
+import { useState } from "react";
+import { useMembers } from "@/data/queries";
+import { useApply } from "@/data/mutations";
+import { ops, change } from "@/data/ops";
+import { uuidv7 } from "@/lib/uuid";
+import type { MemberDto } from "@/data/bindings";
+
+export function AssigneePicker({
+  prefix,
+  issueId,
+  projectId,
+  assigneeId,
+}: {
+  prefix: string;
+  issueId: string;
+  projectId: string;
+  assigneeId: string | null;
+}) {
+  const { data: members = [] } = useMembers(prefix);
+  const apply = useApply(prefix);
+  const [name, setName] = useState("");
+
+  const assign = (value: string) => {
+    apply.mutate(
+      ops.updateIssueField({ id: issueId, change: change.assignee(value || null) }),
+    );
+  };
+
+  const add = () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    apply.mutate(ops.createMember({ id: uuidv7(), project_id: projectId, name: trimmed }));
+    setName("");
+  };
+
+  const remove = (member: MemberDto) => {
+    apply.mutate(ops.deleteMember({ id: member.id }));
+  };
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label className="flex items-center gap-2 text-neutral-500">
+        <span>Assignee</span>
+        <select
+          aria-label="Assignee"
+          value={assigneeId ?? ""}
+          onChange={(e) => assign(e.target.value)}
+          className="rounded border border-black/15 bg-transparent px-1.5 py-0.5 text-xs dark:border-white/15"
+        >
+          <option value="">Unassigned</option>
+          {members.map((m: MemberDto) => (
+            <option key={m.id} value={m.id}>
+              {m.name}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <div className="flex items-center gap-1.5">
+        <input
+          type="text"
+          aria-label="New member name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") add();
+          }}
+          placeholder="Add member"
+          className="min-w-0 flex-1 rounded border border-black/15 bg-transparent px-1.5 py-0.5 text-xs dark:border-white/15"
+        />
+        <button
+          type="button"
+          onClick={add}
+          className="rounded border border-black/15 px-1.5 py-0.5 text-xs hover:bg-black/5 dark:border-white/15 dark:hover:bg-white/10"
+        >
+          Add
+        </button>
+      </div>
+
+      {members.length > 0 && (
+        <ul className="flex flex-wrap gap-1">
+          {members.map((m: MemberDto) => (
+            <li
+              key={m.id}
+              className="inline-flex items-center gap-1 rounded-full border border-black/10 px-2 py-0.5 dark:border-white/10"
+            >
+              <span>{m.name}</span>
+              <button
+                type="button"
+                aria-label={`Remove member ${m.name}`}
+                onClick={() => remove(m)}
+                className="text-neutral-500 hover:text-neutral-900 dark:hover:text-white"
+              >
+                ×
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/detail/IssuePanel.tsx
+++ b/ui/src/components/detail/IssuePanel.tsx
@@ -6,6 +6,7 @@ import { ops, change, PRIORITIES, type Priority } from "@/data/ops";
 import { EditableField } from "./EditableField";
 import { EditableDescription } from "./EditableDescription";
 import { LabelPicker } from "./LabelPicker";
+import { AssigneePicker } from "./AssigneePicker";
 
 export function IssuePanel() {
   const { prefix = "", key = "" } = useParams();
@@ -101,6 +102,15 @@ export function IssuePanel() {
               className="rounded border border-black/15 bg-transparent px-1.5 py-0.5 text-xs dark:border-white/15"
             />
           </label>
+        </div>
+
+        <div className="border-b border-black/10 px-5 py-2.5 text-xs dark:border-white/10">
+          <AssigneePicker
+            prefix={prefix}
+            issueId={issue.id}
+            projectId={issue.project_id}
+            assigneeId={issue.assignee_id}
+          />
         </div>
 
         <div className="flex flex-wrap items-center gap-1.5 border-b border-black/10 px-5 py-2.5 text-xs dark:border-white/10">

--- a/ui/src/data/bindings.ts
+++ b/ui/src/data/bindings.ts
@@ -105,6 +105,22 @@ async listLabels(project: string) : Promise<Result<LabelDto[], ApiError>> {
 }
 },
 /**
+ * Tauri command: list the members of the project identified by `project` (its prefix).
+ * 
+ * # Errors
+ * 
+ * Returns an error if the workspace mutex is poisoned, the blocking task fails
+ * to join, or the underlying query fails.
+ */
+async listMembers(project: string) : Promise<Result<MemberDto[], ApiError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("list_members", { project }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
  * Tauri command: read the GUI settings.
  * 
  * # Errors
@@ -213,9 +229,10 @@ export type ApiError =
  * Result of applying an operation: the new `operation_log` row id.
  */
 export type ApplyResult = { op_id: number }
-export type IssueDto = { id: string; project_id: string; seq: number; identifier: string; title: string; description: string | null; status_id: string; priority: string; due_date: string | null; sort_key: number; created_at: string; updated_at: string; labels: LabelDto[] | null }
+export type IssueDto = { id: string; project_id: string; seq: number; identifier: string; title: string; description: string | null; status_id: string; priority: string; due_date: string | null; assignee_id: string | null; sort_key: number; created_at: string; updated_at: string; labels: LabelDto[] | null }
 export type JsonValue = null | boolean | number | string | JsonValue[] | Partial<{ [key in string]: JsonValue }>
 export type LabelDto = { id: string; project_id: string; name: string; color: string }
+export type MemberDto = { id: string; project_id: string; name: string }
 export type ProjectDto = { id: string; name: string; prefix: string; description: string | null; icon: string | null; status: string; created_at: string; updated_at: string }
 /**
  * App-level settings surfaced to the GUI.

--- a/ui/src/data/mutations.ts
+++ b/ui/src/data/mutations.ts
@@ -74,6 +74,11 @@ function invalidateFor(qc: QueryClient, op: Operation, prefix?: string): void {
       void qc.invalidateQueries({ queryKey: qk.issues(prefix) });
     }
   }
+  if (["CreateMember", "UpdateMember", "DeleteMember"].includes(tag)) {
+    if (prefix) void qc.invalidateQueries({ queryKey: qk.members(prefix) });
+    // A member delete nulls out assignees, so refresh issues + any open detail panel.
+    void qc.invalidateQueries({ queryKey: ["issues"] });
+  }
   if (tag === "ImportSnapshot") void qc.invalidateQueries();
 }
 

--- a/ui/src/data/ops.ts
+++ b/ui/src/data/ops.ts
@@ -26,7 +26,8 @@ export type IssueFieldChange =
   | { field: "Description"; value: string | null }
   | { field: "Status"; value: string } // status_id (uuid)
   | { field: "Priority"; value: Priority }
-  | { field: "DueDate"; value: string | null }; // "YYYY-MM-DD" or null
+  | { field: "DueDate"; value: string | null } // "YYYY-MM-DD" or null
+  | { field: "Assignee"; value: string | null }; // member_id (uuid) or null
 
 export interface Operation {
   op: string;
@@ -150,6 +151,19 @@ export const ops = {
   archiveProject: (args: { id: string }): Operation => ({ op: "ArchiveProject", args }),
 
   deleteProject: (args: { id: string }): Operation => ({ op: "DeleteProject", args }),
+
+  createMember: (args: { id: string; project_id: string; name: string }): Operation => ({
+    op: "CreateMember",
+    args,
+  }),
+
+  updateMember: (args: { id: string; name?: string }): Operation => {
+    const patch: Record<string, unknown> = {};
+    if (args.name !== undefined) patch.name = args.name;
+    return { op: "UpdateMember", args: { id: args.id, patch } };
+  },
+
+  deleteMember: (args: { id: string }): Operation => ({ op: "DeleteMember", args }),
 } as const;
 
 export const change = {
@@ -158,4 +172,5 @@ export const change = {
   status: (v: string): IssueFieldChange => ({ field: "Status", value: v }),
   priority: (v: Priority): IssueFieldChange => ({ field: "Priority", value: v }),
   dueDate: (v: string | null): IssueFieldChange => ({ field: "DueDate", value: v }),
+  assignee: (v: string | null): IssueFieldChange => ({ field: "Assignee", value: v }),
 } as const;

--- a/ui/src/data/queries.ts
+++ b/ui/src/data/queries.ts
@@ -1,7 +1,15 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { commands } from "./bindings";
 import { asApiError } from "./client";
-import type { IssueDto, LabelDto, ProjectDto, Settings, StatusDto, ThemeChoice } from "./bindings";
+import type {
+  IssueDto,
+  LabelDto,
+  MemberDto,
+  ProjectDto,
+  Settings,
+  StatusDto,
+  ThemeChoice,
+} from "./bindings";
 
 /** Query-key factory — keeps invalidation keys consistent across hooks. */
 export const qk = {
@@ -11,6 +19,7 @@ export const qk = {
   issue: (key: string) => ["issues", key] as const,
   statuses: (prefix: string) => ["projects", prefix, "statuses"] as const,
   labels: (prefix: string) => ["projects", prefix, "labels"] as const,
+  members: (prefix: string) => ["projects", prefix, "members"] as const,
   settings: () => ["settings"] as const,
 } as const;
 
@@ -51,6 +60,13 @@ export const useLabels = (prefix: string) =>
   useQuery({
     queryKey: qk.labels(prefix),
     queryFn: () => unwrap<LabelDto[]>(commands.listLabels(prefix)),
+    enabled: !!prefix,
+  });
+
+export const useMembers = (prefix: string) =>
+  useQuery({
+    queryKey: qk.members(prefix),
+    queryFn: () => unwrap<MemberDto[]>(commands.listMembers(prefix)),
     enabled: !!prefix,
   });
 

--- a/ui/tests/components/board/IssueCard.test.tsx
+++ b/ui/tests/components/board/IssueCard.test.tsx
@@ -16,6 +16,7 @@ const issue: IssueDto = {
   status_id: "s1",
   priority: "high",
   due_date: null,
+  assignee_id: null,
   sort_key: 1,
   created_at: "",
   updated_at: "",

--- a/ui/tests/components/detail/AssigneePicker.test.tsx
+++ b/ui/tests/components/detail/AssigneePicker.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { MemberDto } from "@/data/bindings";
+
+const mutate = vi.hoisted(() => vi.fn());
+const members = vi.hoisted<() => MemberDto[]>(() => () => [
+  { id: "m1", project_id: "p1", name: "Ada" },
+  { id: "m2", project_id: "p1", name: "Grace" },
+]);
+
+vi.mock("@/data/mutations", () => ({ useApply: () => ({ mutate, isPending: false }) }));
+vi.mock("@/data/queries", () => ({ useMembers: () => ({ data: members() }) }));
+
+import { AssigneePicker } from "@/components/detail/AssigneePicker";
+
+type Op = { op: string; args: Record<string, unknown> };
+const lastOp = () => mutate.mock.calls.at(-1)?.[0] as Op;
+
+function renderPicker(assigneeId: string | null = null) {
+  return render(
+    <AssigneePicker prefix="AUTH" issueId="u1" projectId="p1" assigneeId={assigneeId} />,
+  );
+}
+
+describe("AssigneePicker", () => {
+  it("lists every member as an option", () => {
+    mutate.mockReset();
+    renderPicker();
+    const select = screen.getByLabelText(/assignee/i);
+    expect(select).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Ada" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Grace" })).toBeInTheDocument();
+  });
+
+  it("selecting a member dispatches an Assignee field change", async () => {
+    mutate.mockReset();
+    renderPicker();
+    await userEvent.selectOptions(screen.getByLabelText(/assignee/i), "m2");
+    const op = lastOp();
+    expect(op.op).toBe("UpdateIssueField");
+    expect(op.args).toMatchObject({ id: "u1", change: { field: "Assignee", value: "m2" } });
+  });
+
+  it("selecting Unassigned dispatches a null Assignee value", async () => {
+    mutate.mockReset();
+    renderPicker("m1");
+    await userEvent.selectOptions(screen.getByLabelText(/assignee/i), "");
+    const op = lastOp();
+    expect(op.op).toBe("UpdateIssueField");
+    expect(op.args).toMatchObject({ id: "u1", change: { field: "Assignee", value: null } });
+  });
+
+  it("adding a member dispatches CreateMember with a generated id", async () => {
+    mutate.mockReset();
+    renderPicker();
+    await userEvent.type(screen.getByLabelText(/new member name/i), "Linus");
+    await userEvent.click(screen.getByRole("button", { name: /^add$/i }));
+    const op = lastOp();
+    expect(op.op).toBe("CreateMember");
+    expect(op.args).toMatchObject({ project_id: "p1", name: "Linus" });
+    expect(typeof op.args.id).toBe("string");
+    expect((op.args.id as string).length).toBeGreaterThan(0);
+  });
+});

--- a/ui/tests/components/detail/IssuePanel.test.tsx
+++ b/ui/tests/components/detail/IssuePanel.test.tsx
@@ -18,6 +18,7 @@ vi.mock("@/data/queries", () => ({
       status_id: "s1",
       priority: "medium",
       due_date: "2026-01-01",
+      assignee_id: "m1",
       labels: [{ id: "l1", project_id: "p1", name: "bug", color: "#f00" }],
     },
     isLoading: false,
@@ -30,6 +31,12 @@ vi.mock("@/data/queries", () => ({
     ],
   }),
   useLabels: () => ({ data: [{ id: "l1", project_id: "p1", name: "bug", color: "#f00" }] }),
+  useMembers: () => ({
+    data: [
+      { id: "m1", project_id: "p1", name: "Ada" },
+      { id: "m2", project_id: "p1", name: "Grace" },
+    ],
+  }),
 }));
 vi.mock("@tauri-apps/plugin-shell", () => ({ open: vi.fn() }));
 
@@ -107,6 +114,11 @@ describe("IssuePanel", () => {
     const op = mutate.mock.calls.at(-1)?.[0] as { op: string; args: Record<string, unknown> };
     expect(op.op).toBe("DetachLabel");
     expect(op.args).toEqual({ issue_id: "u1", label_id: "l1" });
+  });
+
+  it("renders the assignee control", () => {
+    render(<IssuePanel />, { wrapper });
+    expect(screen.getByLabelText(/assignee/i)).toBeInTheDocument();
   });
 
   it("dispatches deleteIssue after confirming delete", async () => {

--- a/ui/tests/data/mutations.test.tsx
+++ b/ui/tests/data/mutations.test.tsx
@@ -85,6 +85,35 @@ describe("useApply optimistic dispatcher", () => {
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: qk.issues("AUTH") });
   });
 
+  it("invalidates members + issues on CreateMember", async () => {
+    applyMock.mockResolvedValueOnce({ status: "ok", data: { op_id: 10 } });
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+
+    const { result } = renderHook(() => useApply("AUTH"), { wrapper: makeWrapper(client) });
+    await act(async () => {
+      result.current.mutate(ops.createMember({ id: "m1", project_id: "p1", name: "Ada" }));
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: qk.members("AUTH") });
+  });
+
+  it("invalidates members + issues on DeleteMember (assignees cleared)", async () => {
+    applyMock.mockResolvedValueOnce({ status: "ok", data: { op_id: 11 } });
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+
+    const { result } = renderHook(() => useApply("AUTH"), { wrapper: makeWrapper(client) });
+    await act(async () => {
+      result.current.mutate(ops.deleteMember({ id: "m1" }));
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: qk.members("AUTH") });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["issues"] });
+  });
+
   it("optimistically adds a created project to the cache on success", async () => {
     applyMock.mockResolvedValueOnce({ status: "ok", data: { op_id: 7 } });
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/ui/tests/data/ops.test.ts
+++ b/ui/tests/data/ops.test.ts
@@ -149,4 +149,37 @@ describe("ops builders", () => {
     expect(ops.deleteProject({ id: "p1" })).toEqual({ op: "DeleteProject", args: { id: "p1" } });
     expect(ops.deleteLabel({ id: "l1" })).toEqual({ op: "DeleteLabel", args: { id: "l1" } });
   });
+
+  it("createMember wraps args under {op,args}", () => {
+    expect(ops.createMember({ id: "m1", project_id: "p1", name: "Ada" })).toEqual({
+      op: "CreateMember",
+      args: { id: "m1", project_id: "p1", name: "Ada" },
+    });
+  });
+
+  it("updateMember wraps a sparse name patch", () => {
+    expect(ops.updateMember({ id: "m1", name: "Grace" })).toEqual({
+      op: "UpdateMember",
+      args: { id: "m1", patch: { name: "Grace" } },
+    });
+  });
+
+  it("updateMember omits undefined name from the patch", () => {
+    expect(ops.updateMember({ id: "m1" })).toEqual({
+      op: "UpdateMember",
+      args: { id: "m1", patch: {} },
+    });
+  });
+
+  it("deleteMember takes just id", () => {
+    expect(ops.deleteMember({ id: "m1" })).toEqual({ op: "DeleteMember", args: { id: "m1" } });
+  });
+
+  it("change.assignee assigns a member id", () => {
+    expect(change.assignee("m1")).toEqual({ field: "Assignee", value: "m1" });
+  });
+
+  it("change.assignee unassigns with null", () => {
+    expect(change.assignee(null)).toEqual({ field: "Assignee", value: null });
+  });
 });

--- a/ui/tests/data/queries.test.tsx
+++ b/ui/tests/data/queries.test.tsx
@@ -12,12 +12,15 @@ vi.mock("@/data/bindings", () => ({
     getIssue: vi.fn(),
     listStatuses: vi.fn(),
     listLabels: vi.fn(),
+    listMembers: vi
+      .fn()
+      .mockResolvedValue({ status: "ok", data: [{ id: "m1", project_id: "p1", name: "Ada" }] }),
     getSettings: vi.fn(),
     updateSettings: vi.fn(),
   },
 }));
 
-import { useProjects } from "@/data/queries";
+import { useMembers, useProjects } from "@/data/queries";
 
 function wrapper({ children }: { children: ReactNode }) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -40,5 +43,18 @@ describe("useProjects", () => {
     const { result } = renderHook(() => useProjects(), { wrapper });
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect((result.current.error as { kind?: string })?.kind).toBe("Internal");
+  });
+});
+
+describe("useMembers", () => {
+  it("returns the member roster for a project prefix", async () => {
+    const { result } = renderHook(() => useMembers("AUTH"), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.[0].name).toBe("Ada");
+  });
+
+  it("is disabled when prefix is empty", () => {
+    const { result } = renderHook(() => useMembers(""), { wrapper });
+    expect(result.current.fetchStatus).toBe("idle");
   });
 });


### PR DESCRIPTION
## Summary

**Spec #6 — Members & Assignees**: a per-project member roster and a single (nullable) assignee per issue, fully undoable. The one schema change of the v2 GUI arc.

**Core (`kanban-core`)**
- **Migration `0003_members.sql`** (append-only): a per-project `members` table (`UNIQUE(project_id,name)`, FK→projects `ON DELETE CASCADE`) + `ALTER TABLE issues ADD COLUMN assignee_id TEXT REFERENCES members(id) ON DELETE SET NULL`.
- Ops `CreateMember`/`UpdateMember`/`DeleteMember` (mirror the label ops). **Assignment reuses `UpdateIssueField`** via a new `IssueFieldChange::Assignee(Option<Uuid>)` — validated so a member must belong to the issue's project.
- **Undo:** `WorkspaceSnapshot` gained `members` (schema **v1→v2**); `DeleteMember`'s inverse is an `ImportSnapshot` capturing the member, its assigned issues, **and their `issue_labels`** (so undo restores the roster, the assignments, and label attachments). `Issue.assignee_id` threads through `row_to_issue` and every snapshot path.

**Tauri/GUI** — `MemberDto` + `list_members`; `IssueDto.assignee_id`; an assignee picker + member roster in the issue detail panel (bindings regenerated, drift-clean).

**CLI** — `kanban member list|create|update|delete` and `kanban issue assign <key> <member> | --unassign` (unknown/foreign member → non-zero exit).

**Deferred to Spec #7:** MCP member/assignee tools; board-card assignee avatar; multi-assignee.

## Test plan
- [x] Rust: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` — green (core member+assignment tests incl. delete-member-undo-restores-assignment-and-labels; migration test; CLI `member_cmds`/`issue_assign`).
- [x] UI: `pnpm typecheck`, `pnpm lint` (no `any`), `pnpm test:unit` (108), `pnpm build` — green; bindings drift-clean.
- [x] Migration append-only (0001/0002 untouched); single-mutator invariant preserved (all writes via `Workspace::apply`).
- [ ] Manual smoke: add members, assign/unassign an issue, delete a member (its issues unassign) then ⌘Z — in the app and via `kanban member` / `kanban issue assign`.