### PR TITLE
fix(core): redo-branch truncation trips activity_log FK

### DIFF
--- a/crates/kanban-core/src/store/write/operation_log.rs
+++ b/crates/kanban-core/src/store/write/operation_log.rs
@@ -63,6 +63,15 @@ pub(crate) fn set_op_undone(tx: &Transaction<'_>, op_id: i64, undone: bool) -> R
 // Used by Tasks 10+ (applier). Allow dead_code until wired up.
 #[allow(dead_code)]
 pub(crate) fn truncate_redo_branch(tx: &Transaction<'_>) -> Result<()> {
+    // `activity_log.op_id` references `operation_log(id)` with NO ACTION, so the
+    // dependent activity rows for the discarded branch must be removed before
+    // their operation rows — otherwise the parent delete trips the FK. A redo
+    // branch can never be redone, so its forward-change activity entries go too.
+    tx.execute(
+        "DELETE FROM activity_log WHERE op_id IN \
+         (SELECT id FROM operation_log WHERE undone = 1)",
+        [],
+    )?;
     tx.execute("DELETE FROM operation_log WHERE undone = 1", [])?;
     Ok(())
 }
@@ -153,5 +162,28 @@ mod tests {
             .unwrap();
         assert_eq!(live_exists, 1);
         assert_eq!(dead_exists, 0);
+    }
+
+    #[test]
+    fn truncate_redo_branch_removes_dependent_activity_rows() {
+        // activity_log.op_id -> operation_log is NO ACTION, so truncation must
+        // delete the branch's activity rows first or the parent delete trips
+        // the FK (foreign_keys is ON for in-memory connections).
+        let mut c = fresh_tx_owner();
+        let now = Utc::now();
+        let tx = c.transaction().unwrap();
+        let dead = insert_operation(&tx, "D", "{}", "{}", now).unwrap();
+        insert_activity(&tx, dead, None, "title", Some("a"), Some("b"), now).unwrap();
+        set_op_undone(&tx, dead, true).unwrap();
+        truncate_redo_branch(&tx).unwrap();
+        tx.commit().unwrap();
+        let activities: i64 = c
+            .query_row(
+                "SELECT COUNT(*) FROM activity_log WHERE op_id = ?1",
+                params![dead],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(activities, 0);
     }
 }

--- a/crates/kanban-core/tests/undo_redo.rs
+++ b/crates/kanban-core/tests/undo_redo.rs
@@ -97,3 +97,68 @@ fn undo_persists_across_workspace_open() {
         assert_eq!(p.prefix, "PER");
     }
 }
+
+#[test]
+fn forward_op_after_undoing_an_activity_emitting_op_succeeds() {
+    // Regression: a new forward op truncates the redo branch by deleting the
+    // undone `operation_log` rows. Ops like `UpdateIssueField` also write an
+    // `activity_log` row (FK `op_id -> operation_log`, NO ACTION). Those
+    // children must be removed before their parent rows, or the truncation
+    // fails with "FOREIGN KEY constraint failed". `CreateProject` emits no
+    // activity row, which is why the existing truncation test missed this.
+    use kanban_core::operation::{CreateIssue, IssueFieldChange, UpdateIssueField};
+    use kanban_core::types::Priority;
+
+    let mut ws = Workspace::open_in_memory().unwrap();
+    let pid = new_id();
+    ws.apply(Operation::CreateProject(CreateProject {
+        id: pid,
+        name: "P".into(),
+        prefix: "PRJ".into(),
+        description: None,
+        icon: None,
+    }))
+    .unwrap();
+    let status_id = ws.query_statuses_for_project(pid).unwrap()[0].id;
+
+    let iid = new_id();
+    ws.apply(Operation::CreateIssue(CreateIssue {
+        id: iid,
+        project_id: pid,
+        title: "v1".into(),
+        description: None,
+        status_id,
+        priority: Priority::Medium,
+        due_date: None,
+        label_ids: vec![],
+    }))
+    .unwrap();
+
+    // An UpdateIssueField writes an activity_log row linked to its op_id.
+    ws.apply(Operation::UpdateIssueField(UpdateIssueField {
+        id: iid,
+        change: IssueFieldChange::Title("v2".into()),
+    }))
+    .unwrap();
+
+    // Undo marks that op as a redo-branch entry; its activity row remains.
+    ws.undo().unwrap();
+
+    // A new forward op must truncate the redo branch without an FK error.
+    let iid2 = new_id();
+    ws.apply(Operation::CreateIssue(CreateIssue {
+        id: iid2,
+        project_id: pid,
+        title: "another".into(),
+        description: None,
+        status_id,
+        priority: Priority::Medium,
+        due_date: None,
+        label_ids: vec![],
+    }))
+    .unwrap();
+
+    // The new issue exists and the redo branch is gone.
+    assert!(ws.query_issue_by_id(iid2).is_ok());
+    assert!(ws.redo().is_err());
+}


### PR DESCRIPTION
## Bug

Applying a new operation after an undo fails with `FOREIGN KEY constraint failed` whenever the undone operation had written an `activity_log` row.

Reproduce (CLI):
```sh
kanban issue update GEN-1 --title v2
kanban undo
kanban issue create --project GEN --title another   # error: FOREIGN KEY constraint failed
```
Also hit via `assign → unassign → undo → delete member` — which is how it surfaced while demoing the Spec #6/#7 member/assignee work.

## Root cause

A new forward op discards the redo branch via `truncate_redo_branch`, which ran:
```sql
DELETE FROM operation_log WHERE undone = 1;
```
Ops like `UpdateIssueField` also insert an `activity_log` row whose `op_id` references `operation_log(id)` with **`ON DELETE NO ACTION`**. Deleting the parent rows left those children dangling, so SQLite rejected the delete.

**Pre-existing and general** — not specific to members/assignees. The existing `forward_op_truncates_redo_branch` test only used `CreateProject`, which emits no `activity_log` row, so the FK child was never exercised.

## Fix

Delete the discarded branch's `activity_log` rows before their `operation_log` rows, in the same transaction. A redo branch can never be redone, so its forward-change activity entries are discarded with it.

## Tests (both fail before the fix)
- `crates/kanban-core/tests/undo_redo.rs::forward_op_after_undoing_an_activity_emitting_op_succeeds` — faithful `UpdateIssueField → undo → CreateIssue` regression.
- `operation_log.rs::truncate_redo_branch_removes_dependent_activity_rows` — focused unit test inserting a dependent activity row.

Full gate green: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace`.